### PR TITLE
chore: set different ports for React projects

### DIFF
--- a/relay-reactjs-chat/package.json
+++ b/relay-reactjs-chat/package.json
@@ -14,7 +14,7 @@
     "react-scripts": "5.0.1"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "PORT=3001 craco start",
     "build": "craco build",
     "test": "exit 0",
     "eject": "craco eject"

--- a/store-reactjs-chat/package.json
+++ b/store-reactjs-chat/package.json
@@ -15,7 +15,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3002 react-scripts start",
     "build": "react-scripts build",
     "test": "exit 0",
     "eject": "react-scripts eject"

--- a/web-chat/package.json
+++ b/web-chat/package.json
@@ -29,7 +29,7 @@
     "url": "^0.11.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3003 react-scripts start",
     "build": "react-scripts build",
     "test:unit": "exit 0",
     "fix": "run-s fix:*",


### PR DESCRIPTION
So two examples can be started at the same time to test things faster.