### PR TITLE
feat: use same content topics across examples when possible

### DIFF
--- a/light-js/index.html
+++ b/light-js/index.html
@@ -106,12 +106,14 @@
     subscribeButton.onclick = async () => {
         unsubscribe = await node.filter.subscribe(callback, [ContentTopic])
         unsubscribeButton.disabled = false;
+        subscribeButton.disabled = true;
     }
 
     unsubscribeButton.onclick = async () => {
         await unsubscribe();
         unsubscribe = undefined
         unsubscribeButton.disabled = true;
+        subscribeButton.disabled = false;
     }
 
     sendButton.onclick = async () => {

--- a/light-js/index.html
+++ b/light-js/index.html
@@ -56,7 +56,7 @@
     const textInput = document.getElementById('textInput');
     const sendButton = document.getElementById('sendButton');
 
-    const ContentTopic = "/light-js/0/message/utf8";
+    const ContentTopic = "/js-waku-examples/1/chat/utf8";
     let messages = []
     let unsubscribe;
 

--- a/relay-angular-chat/src/app/messages/messages.component.ts
+++ b/relay-angular-chat/src/app/messages/messages.component.ts
@@ -19,7 +19,7 @@ interface MessageInterface {
   styleUrls: ["./messages.component.css"],
 })
 export class MessagesComponent implements OnInit {
-  contentTopic: string = `/relay-angular-chat/1/chat/proto`;
+  contentTopic: string = `/js-waku-examples/1/chat/proto`;
   messages: MessageInterface[] = [];
   messageCount: number = 0;
   waku!: WakuPrivacy;

--- a/relay-js/index.html
+++ b/relay-js/index.html
@@ -50,7 +50,7 @@
     // Recommendation: `/dapp-name/version/functionality/codec`
     // We recommend to use protobuf as codec (`proto`), this demo uses utf-8
     // for simplicity's sake.
-    const contentTopic = '/relay-demo/1/message/utf-8';
+    const contentTopic = '/js-waku-examples/1/chat/utf8';
 
     try {
         statusDiv.innerHTML = '<p>Starting</p>';

--- a/relay-reactjs-chat/src/App.js
+++ b/relay-reactjs-chat/src/App.js
@@ -4,7 +4,7 @@ import protobuf from "protobufjs";
 import { createPrivacyNode } from "js-waku/lib/create_waku";
 import { waitForRemotePeer } from "js-waku/lib/wait_for_remote_peer";
 
-const ContentTopic = `/relay-reactjs-chat/1/chat/proto`;
+const ContentTopic = `/js-waku-examples/1/chat/proto`;
 
 const SimpleChatMessage = new protobuf.Type("SimpleChatMessage")
   .add(new protobuf.Field("timestamp", 1, "uint32"))


### PR DESCRIPTION
All examples do not connect to the same fleet at the moment so the gain is limited.