### PR TITLE
Fix Jenkins CI by escaping brackets 

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -79,5 +79,5 @@ def buildExample(example=STAGE_NAME) {
 
 def copyExample(example=STAGE_NAME) {
   sh "mkdir -p build/docs/${example}"
-  sh "cp examples/${example}/*.{js|css|html} build/docs/${example}/"
+  sh "cp examples/${example}/*.\(js|css|html\) build/docs/${example}/"
 }


### PR DESCRIPTION
Since prev PR didn't fix the issue 
https://github.com/waku-org/js-waku-examples/pull/178
