### PR TITLE
ci: simplify overcomplicated file copying

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -53,7 +53,6 @@ pipeline {
     }
 
     stage('Publish') {
-      //when { expression { GIT_BRANCH.endsWith('master') } }
       steps { script {
         sh "echo ${SITE_DOMAIN} > build/docs/CNAME"
         sshagent(credentials: ['status-im-auto-ssh']) {
@@ -80,42 +79,6 @@ def buildExample(example=STAGE_NAME) {
 def copyExample(example=STAGE_NAME) {
   def source = "examples/${example}"
   def dest = "build/docs/${example}"
-
   sh "mkdir -p ${dest}"
-  
-  try {
-    sh "cp ${source}/*.js ${dest}/"
-  } catch (e) {
-    echo "No JS files found."
-  }
-
-  try {
-    sh "cp ${source}/*.css ${dest}/"
-  } catch (e) {
-    echo "No CSS files found."
-  }
-
-  try {
-    sh "cp ${source}/*.html ${dest}/"
-  } catch (e) {
-    echo "No HTML files found."
-  }
-
-  try {
-    sh "cp ${source}/*.json ${dest}/"
-  } catch (e) {
-    echo "No JSON files found."
-  }
-
-  try {
-    sh "cp ${source}/*.png ${dest}/"
-  } catch (e) {
-    echo "No PNG files found."
-  }
-
-  try {
-    sh "cp ${source}/*.ico ${dest}/"
-  } catch (e) {
-    echo "No ICO files found."
-  }
+  sh "cp -r ${source}/. ${dest}"
 }


### PR DESCRIPTION
Not sure why this massive construction was added:
https://github.com/waku-org/js-waku-examples/blob/622aecb422f925feefee65b3bd0d0014bd439342/ci/Jenkinsfile#L86-L120
When we can just `cp` stuff:
https://github.com/waku-org/js-waku-examples/blob/012ef6089b399a35df5d8305bec29e6880ae34fa/ci/Jenkinsfile#L83