### PR TITLE
feat: use dns-discovery instead of predefined list

### DIFF
--- a/examples/web-chat/.cspell.json
+++ b/examples/web-chat/.cspell.json
@@ -3,6 +3,7 @@
   "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/master/cspell.schema.json",
   "language": "en",
   "words": [
+    "AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM",
     "asym",
     "backoff",
     "backoffs",

--- a/examples/web-chat/package-lock.json
+++ b/examples/web-chat/package-lock.json
@@ -14,6 +14,7 @@
         "@waku/byte-utils": "^0.0.2",
         "@waku/core": "^0.0.6",
         "@waku/create": "^0.0.4",
+        "@waku/dns-discovery": "0.0.4",
         "@waku/interfaces": "^0.0.5",
         "process": "^0.11.10",
         "protons-runtime": "^3.1.0",
@@ -2990,6 +2991,58 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ]
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -3868,11 +3921,42 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/base64-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/base64-codec/-/base64-codec-1.0.0.tgz",
+      "integrity": "sha512-0cgP4lRBzh3F4tlpTfs7F+PJyBN8j5yUC9KrQFWp/bREswgzZVHE8T1rNyRDWgvALwwpPtnJDQfqWUmxI33Epg=="
+    },
+    "node_modules/@leichtgewicht/dns-packet": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/dns-packet/-/dns-packet-6.0.3.tgz",
+      "integrity": "sha512-qmVHhFBFiBvPsk/wJ/EdoWHb+tGkzY4haybmDPukhF6w0+8wpEbrHTIRE9LzeUu2P0bAbmrK8WOXt5V5QN6jQg==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "bytes.js": "^0.0.2",
+        "utf8-bytes": "^0.0.1",
+        "utf8-codec": "^1.0.0",
+        "utf8-length": "^0.0.1",
+        "utf8-string-bytes": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@leichtgewicht/dns-socket": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/dns-socket/-/dns-socket-5.0.0.tgz",
+      "integrity": "sha512-Sbrn/OG0HTTPGSkwIDCHy8/tUI6UglIzFsMNjzZn/Na1/i5owSm6rVi9CfKNNjRcUlYEzICELYW6EoZdjwVY2A==",
+      "dependencies": {
+        "@leichtgewicht/dns-packet": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
-      "dev": true
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@libp2p/bootstrap": {
       "version": "5.0.2",
@@ -6506,6 +6590,48 @@
         "node": ">=16"
       }
     },
+    "node_modules/@waku/dns-discovery": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.4.tgz",
+      "integrity": "sha512-XwlDLHh0q2E+hH6fQa7sGiT0wTAoAfehYfo21iJUEnGbVRJY0LHXQAm7aMSOSZTXe8ctHQ6ukeu5ykR0vC2Oeg==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/interface-peer-info": "^1.0.1",
+        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/peer-id": "^1.1.10",
+        "@waku/byte-utils": "*",
+        "@waku/enr": "*",
+        "@waku/libp2p-utils": "*",
+        "chai": "^4.3.4",
+        "debug": "^4.3.4",
+        "dns-query": "^0.11.2",
+        "hi-base32": "^0.5.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/enr": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.4.tgz",
+      "integrity": "sha512-BQ/nQbhddE1hvxijJP7/Il+z5mymapU8xnax09UCZEGX9wVQBbHbzsSX6ARhfwCqBTNNsR5hlOhLISRr8H+43g==",
+      "dependencies": {
+        "@ethersproject/rlp": "^5.5.0",
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-peer-id": "^1.0.2",
+        "@libp2p/peer-id": "^1.1.10",
+        "@multiformats/multiaddr": "^11.0.6",
+        "@noble/secp256k1": "^1.3.4",
+        "@waku/byte-utils": "*",
+        "chai": "^4.3.6",
+        "debug": "^4.3.4",
+        "js-sha3": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@waku/interfaces": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.5.tgz",
@@ -6517,6 +6643,23 @@
         "@libp2p/interface-peer-store": "^1.2.3",
         "@multiformats/multiaddr": "^11.0.6",
         "libp2p": "0.40.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/libp2p-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@waku/libp2p-utils/-/libp2p-utils-0.0.2.tgz",
+      "integrity": "sha512-Zc4vFvKz62QAVCRd4648tvZRHEpclh/jZlR0dFFXjp5gpKE1W1/2kh31odTroPzAMwZiASHJUjel4Z1M/BCUhw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^3.0.3",
+        "@libp2p/interface-peer-id": "^1.0.6",
+        "@libp2p/interface-peer-info": "^1.0.1",
+        "@libp2p/interface-peer-store": "^1.2.3",
+        "@libp2p/peer-id": "^1.1.10",
+        "@multiformats/multiaddr": "^11.0.6",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">=16"
@@ -7140,6 +7283,14 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -7760,6 +7911,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/bytes.js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/bytes.js/-/bytes.js-0.0.2.tgz",
+      "integrity": "sha512-KrLm4hv5Qs9w6b0U7h1bCdqxrsf+e9QMsfHeyQFzAz94x/5Aqa+FTEUSNBtt5d2VuV3Hfiea3c4ti74RZDDYkg=="
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -8038,6 +8194,23 @@
         "node": ">= 10"
       }
     },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -8071,6 +8244,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/check-types": {
@@ -9405,6 +9586,17 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -9629,6 +9821,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dns-query": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/dns-query/-/dns-query-0.11.2.tgz",
+      "integrity": "sha512-zF8qxQpqCB467o4A63DLpQClo77H642JEKMx0Ra9GFww7Rx0234Fo8NoG0LBoSBZxamWkXfLxhzDG19bTBHvXQ==",
+      "dependencies": {
+        "@leichtgewicht/base64-codec": "^1.0.0",
+        "@leichtgewicht/dns-packet": "^6.0.2",
+        "@leichtgewicht/dns-socket": "^5.0.0",
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "bin": {
+        "dns-query": "bin/dns-query"
       }
     },
     "node_modules/doctrine": {
@@ -11719,6 +11926,14 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -12159,6 +12374,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
+    "node_modules/hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -15664,6 +15884,11 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16331,6 +16556,14 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dependencies": {
+        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lower-case": {
@@ -17152,9 +17385,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -17661,6 +17894,14 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/performance-now": {
@@ -22343,7 +22584,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -22739,6 +22979,26 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+    },
+    "node_modules/utf8-bytes": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+      "integrity": "sha512-GifWmJAx2qAXT+lZLhbkWhBsy7pr6xWHiPWlVToDiELdWgZwt4Ogjf9tlgvKuALzTFR/d+EPQQI9ogJV3957Jg=="
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w=="
+    },
+    "node_modules/utf8-length": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
+      "integrity": "sha512-j/XH2ftofBiobnyApxlN/J6j/ixwT89WEjDcjT66d2i0+GIn9RZfzt8lpEXXE4jUe4NsjBSUq70kS2euQ4nnMw=="
+    },
+    "node_modules/utf8-string-bytes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/utf8-string-bytes/-/utf8-string-bytes-1.0.3.tgz",
+      "integrity": "sha512-i/I1Omf6lADjVBlwJpQifZOePV15snHny9w04+lc71+3t8PyWuLC/7clyoOSHOBNGXFe2PAGxmTiZ+Z4HWsPyw=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -26042,6 +26302,28 @@
         }
       }
     },
+    "@ethersproject/bytes": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "requires": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+    },
+    "@ethersproject/rlp": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "requires": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -26714,11 +26996,36 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@leichtgewicht/base64-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/base64-codec/-/base64-codec-1.0.0.tgz",
+      "integrity": "sha512-0cgP4lRBzh3F4tlpTfs7F+PJyBN8j5yUC9KrQFWp/bREswgzZVHE8T1rNyRDWgvALwwpPtnJDQfqWUmxI33Epg=="
+    },
+    "@leichtgewicht/dns-packet": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/dns-packet/-/dns-packet-6.0.3.tgz",
+      "integrity": "sha512-qmVHhFBFiBvPsk/wJ/EdoWHb+tGkzY4haybmDPukhF6w0+8wpEbrHTIRE9LzeUu2P0bAbmrK8WOXt5V5QN6jQg==",
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "bytes.js": "^0.0.2",
+        "utf8-bytes": "^0.0.1",
+        "utf8-codec": "^1.0.0",
+        "utf8-length": "^0.0.1",
+        "utf8-string-bytes": "^1.0.3"
+      }
+    },
+    "@leichtgewicht/dns-socket": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/dns-socket/-/dns-socket-5.0.0.tgz",
+      "integrity": "sha512-Sbrn/OG0HTTPGSkwIDCHy8/tUI6UglIzFsMNjzZn/Na1/i5owSm6rVi9CfKNNjRcUlYEzICELYW6EoZdjwVY2A==",
+      "requires": {
+        "@leichtgewicht/dns-packet": "^6.0.0"
+      }
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
-      "dev": true
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@libp2p/bootstrap": {
       "version": "5.0.2",
@@ -28773,6 +29080,42 @@
         "@waku/interfaces": "*"
       }
     },
+    "@waku/dns-discovery": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.4.tgz",
+      "integrity": "sha512-XwlDLHh0q2E+hH6fQa7sGiT0wTAoAfehYfo21iJUEnGbVRJY0LHXQAm7aMSOSZTXe8ctHQ6ukeu5ykR0vC2Oeg==",
+      "requires": {
+        "@libp2p/interface-peer-discovery": "^1.0.0",
+        "@libp2p/interface-peer-info": "^1.0.1",
+        "@libp2p/interfaces": "^3.0.2",
+        "@libp2p/peer-id": "^1.1.10",
+        "@waku/byte-utils": "*",
+        "@waku/enr": "*",
+        "@waku/libp2p-utils": "*",
+        "chai": "^4.3.4",
+        "debug": "^4.3.4",
+        "dns-query": "^0.11.2",
+        "hi-base32": "^0.5.1",
+        "uint8arrays": "^4.0.2"
+      }
+    },
+    "@waku/enr": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.4.tgz",
+      "integrity": "sha512-BQ/nQbhddE1hvxijJP7/Il+z5mymapU8xnax09UCZEGX9wVQBbHbzsSX6ARhfwCqBTNNsR5hlOhLISRr8H+43g==",
+      "requires": {
+        "@ethersproject/rlp": "^5.5.0",
+        "@libp2p/crypto": "^1.0.4",
+        "@libp2p/interface-peer-id": "^1.0.2",
+        "@libp2p/peer-id": "^1.1.10",
+        "@multiformats/multiaddr": "^11.0.6",
+        "@noble/secp256k1": "^1.3.4",
+        "@waku/byte-utils": "*",
+        "chai": "^4.3.6",
+        "debug": "^4.3.4",
+        "js-sha3": "^0.8.0"
+      }
+    },
     "@waku/interfaces": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.5.tgz",
@@ -28784,6 +29127,20 @@
         "@libp2p/interface-peer-store": "^1.2.3",
         "@multiformats/multiaddr": "^11.0.6",
         "libp2p": "0.40.0"
+      }
+    },
+    "@waku/libp2p-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@waku/libp2p-utils/-/libp2p-utils-0.0.2.tgz",
+      "integrity": "sha512-Zc4vFvKz62QAVCRd4648tvZRHEpclh/jZlR0dFFXjp5gpKE1W1/2kh31odTroPzAMwZiASHJUjel4Z1M/BCUhw==",
+      "requires": {
+        "@libp2p/interface-connection": "^3.0.3",
+        "@libp2p/interface-peer-id": "^1.0.6",
+        "@libp2p/interface-peer-info": "^1.0.1",
+        "@libp2p/interface-peer-store": "^1.2.3",
+        "@libp2p/peer-id": "^1.1.10",
+        "@multiformats/multiaddr": "^11.0.6",
+        "debug": "^4.3.4"
       }
     },
     "@webassemblyjs/ast": {
@@ -29296,6 +29653,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -29772,6 +30134,11 @@
       "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true
     },
+    "bytes.js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/bytes.js/-/bytes.js-0.0.2.tgz",
+      "integrity": "sha512-KrLm4hv5Qs9w6b0U7h1bCdqxrsf+e9QMsfHeyQFzAz94x/5Aqa+FTEUSNBtt5d2VuV3Hfiea3c4ti74RZDDYkg=="
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -30017,6 +30384,20 @@
         "lodash": "^4.17.15"
       }
     },
+    "chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -30044,6 +30425,11 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA=="
     },
     "check-types": {
       "version": "11.2.2",
@@ -31041,6 +31427,14 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
+    "deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -31207,6 +31601,18 @@
       "dev": true,
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.1"
+      }
+    },
+    "dns-query": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/dns-query/-/dns-query-0.11.2.tgz",
+      "integrity": "sha512-zF8qxQpqCB467o4A63DLpQClo77H642JEKMx0Ra9GFww7Rx0234Fo8NoG0LBoSBZxamWkXfLxhzDG19bTBHvXQ==",
+      "requires": {
+        "@leichtgewicht/base64-codec": "^1.0.0",
+        "@leichtgewicht/dns-packet": "^6.0.2",
+        "@leichtgewicht/dns-socket": "^5.0.0",
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
       }
     },
     "doctrine": {
@@ -32797,6 +33203,11 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig=="
+    },
     "get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -33128,6 +33539,11 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+    },
+    "hi-base32": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -35727,6 +36143,11 @@
       "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
       "dev": true
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -36258,6 +36679,14 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "requires": {
+        "get-func-name": "^2.0.0"
       }
     },
     "lower-case": {
@@ -36870,9 +37299,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
     "object-keys": {
@@ -37219,6 +37648,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -40581,8 +41015,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "1.4.0",
@@ -40853,6 +41286,26 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+    },
+    "utf8-bytes": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-bytes/-/utf8-bytes-0.0.1.tgz",
+      "integrity": "sha512-GifWmJAx2qAXT+lZLhbkWhBsy7pr6xWHiPWlVToDiELdWgZwt4Ogjf9tlgvKuALzTFR/d+EPQQI9ogJV3957Jg=="
+    },
+    "utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w=="
+    },
+    "utf8-length": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
+      "integrity": "sha512-j/XH2ftofBiobnyApxlN/J6j/ixwT89WEjDcjT66d2i0+GIn9RZfzt8lpEXXE4jUe4NsjBSUq70kS2euQ4nnMw=="
+    },
+    "utf8-string-bytes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/utf8-string-bytes/-/utf8-string-bytes-1.0.3.tgz",
+      "integrity": "sha512-i/I1Omf6lADjVBlwJpQifZOePV15snHny9w04+lc71+3t8PyWuLC/7clyoOSHOBNGXFe2PAGxmTiZ+Z4HWsPyw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/examples/web-chat/package.json
+++ b/examples/web-chat/package.json
@@ -11,6 +11,7 @@
     "@waku/core": "^0.0.6",
     "@waku/create": "^0.0.4",
     "@waku/interfaces": "^0.0.5",
+    "@waku/dns-discovery": "0.0.4",
     "process": "^0.11.10",
     "protons-runtime": "^3.1.0",
     "react": "^17.0.2",

--- a/examples/web-chat/src/types/types.d.ts
+++ b/examples/web-chat/src/types/types.d.ts
@@ -1,1 +1,2 @@
 declare module "@livechat/ui-kit";
+declare module "@waku/dns-discovery";


### PR DESCRIPTION
## This PR
Uses DNS Discovery to find nodes instead of providing a predefined list of nodes

## Notes
Declares a module for `@waku/dns-discovery` (ref: https://github.com/waku-org/js-waku/issues/1124) -- will be followed up by another PR -- tracking here: https://github.com/waku-org/js-waku-examples/issues/191