### PR TITLE
fix(rln-js): remove `DEFAULT` from `SIGNATURE_MESSAGE` variable

### DIFF
--- a/examples/rln-js/index.html
+++ b/examples/rln-js/index.html
@@ -205,7 +205,7 @@
       let retrievedRLNEvents = false;
       const rlnInstancePromise = create();
 
-      const DEFAULT_SIGNATURE_MESSAGE =
+      const SIGNATURE_MESSAGE =
         "The signature of this message will be used to generate your RLN credentials. Anyone accessing it may send messages on your behalf, please only share with the RLN dApp";
 
       // Load zero-kit WASM blob.
@@ -283,7 +283,7 @@
       importFromWalletButton.onclick = async () => {
         const signer = provider.getSigner();
 
-        const signature = await signer.signMessage(DEFAULT_SIGNATURE_MESSAGE);
+        const signature = await signer.signMessage(SIGNATURE_MESSAGE);
 
         membershipKey = await rlnInstance.generateSeededMembershipKey(
           signature


### PR DESCRIPTION
a value is cannot be a default value if it's not configurable
ref: https://github.com/waku-org/js-waku-examples/pull/171