### PR TITLE
fix: publishing issue of noise-js example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
+build
 node_modules
 yarn.lock

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
         stage('relay-reactjs-chat') { steps { script { buildExample() } } }
         stage('store-reactjs-chat') { steps { script { buildExample() } } }
         stage('web-chat') { steps { script { buildExample() } } }
+        stage('noise-js') { steps { script { buildExample() } } }
       }
     }
 
@@ -49,7 +50,6 @@ pipeline {
         stage('light-js') { steps { script { copyExample() } } }
         stage('rln-js') { steps { script { copyExample() } } }
         stage('light-chat') { steps { script { copyExample() } } }
-        stage('noise-js') { steps { script { copyExample() } } }
       }
     }
 

--- a/examples/noise-js/webpack.config.js
+++ b/examples/noise-js/webpack.config.js
@@ -4,7 +4,7 @@ const path = require("path");
 module.exports = {
   entry: "./index.js",
   output: {
-    path: path.resolve(__dirname, "dist"),
+    path: path.resolve(__dirname, "build"),
     filename: "index.js",
   },
   experiments: {


### PR DESCRIPTION
`noise-js` example should be built and published by our CI
The issue with it breaking pipeline was in wrong name of a folder with build artifact - now it is fixed.

```
+ cp -r build/. /home/jenkins/workspace/website/examples.waku.org/build/docs/noise-js
cp: can't stat 'build/.': No such file or directory
```
