### PR TITLE
chore: make latest as default tag for @waku/create-app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,5 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.WAKU_CREATE_APP_PUBLISH }}" > ./.npmrc
         working-directory: "create-waku-app"
 
-      - run: npm publish --tag next --access public
+      - run: npm publish --tag latest --access public
         working-directory: "create-waku-app"


### PR DESCRIPTION
I think it is safe enough to make publishing with `latest` tag by default. 
