### PR TITLE
chore: add notice about go-waku interop

### DIFF
--- a/examples/noise-js/index.html
+++ b/examples/noise-js/index.html
@@ -188,10 +188,10 @@
 
     <div>
       <p>
-        NOTICE: you can try
+        NOTICE: you can try also try to pair your browser with a
         <a href="https://github.com/waku-org/go-waku/tree/master/examples/noise"
-          >go-waku interop</a
-        >, after running it will give you a link to open.
+          >go-waku based node</a
+        >.
       </p>
     </div>
 

--- a/examples/noise-js/index.html
+++ b/examples/noise-js/index.html
@@ -186,6 +186,15 @@
       </div>
     </div>
 
+    <div>
+      <p>
+        NOTICE: you can try
+        <a href="https://github.com/waku-org/go-waku/tree/master/examples/noise"
+          >go-waku interop</a
+        >, after running it will give you a link to open.
+      </p>
+    </div>
+
     <script src="./index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Shows small message in bottom part of the page.

![image](https://user-images.githubusercontent.com/118575614/229932148-6d86500a-f77a-4295-b1b0-2032ad2ba1a3.png)


relevant to https://github.com/waku-org/js-waku/issues/950