### PR TITLE
chore: use filter directly as receiver

### DIFF
--- a/examples/noise-js/index.js
+++ b/examples/noise-js/index.js
@@ -29,13 +29,12 @@ async function main() {
 
     ui.waku.connected();
 
-    const responder = getResponder(node);
     const myStaticKey = noise.generateX25519KeyPair();
     const urlPairingInfo = getPairingInfoFromURL();
 
     const pairingObj = new noise.WakuPairing(
       node.lightPush,
-      responder,
+      node.filter,
       myStaticKey,
       urlPairingInfo || new noise.ResponderParameters()
     );
@@ -115,59 +114,6 @@ function getPairingInfoFromURL() {
     decodeURIComponent(qrCodeString),
     utils.hexToBytes(messageNameTag)
   );
-}
-
-function getResponder(node) {
-  const msgQueue = new Array();
-  const subscriptions = new Map();
-  const intervals = new Map();
-
-  const responder = {
-    async subscribe(decoder) {
-      const subscription = await node.filter.subscribe(
-        [decoder],
-        (wakuMessage) => {
-          msgQueue.push(wakuMessage);
-        }
-      );
-      subscriptions.set(decoder.contentTopic, subscription);
-    },
-    async nextMessage(contentTopic) {
-      if (msgQueue.length != 0) {
-        const oldestMsg = msgQueue.shift();
-        if (oldestMsg.contentTopic === contentTopic) {
-          return oldestMsg;
-        }
-      }
-
-      return new Promise((resolve) => {
-        const interval = setInterval(() => {
-          if (msgQueue.length != 0) {
-            clearInterval(interval);
-            const oldestMsg = msgQueue.shift();
-            if (oldestMsg.contentTopic === contentTopic) {
-              resolve(oldestMsg);
-            }
-          }
-        }, 100);
-        intervals.set(contentTopic, interval);
-      });
-    },
-    async stop(contentTopic) {
-      if (intervals.has(contentTopic)) {
-        clearInterval(intervals.get(contentTopic));
-        intervals.delete(contentTopic);
-      }
-      if (subscriptions.has(contentTopic)) {
-        await subscriptions.get(contentTopic)();
-        subscriptions.delete(contentTopic);
-      } else {
-        console.log("Subscriptipon doesnt exist");
-      }
-    },
-  };
-
-  return responder;
 }
 
 async function scheduleHandshakeAuthConfirmation(pairingObj, ui) {

--- a/examples/noise-js/package.json
+++ b/examples/noise-js/package.json
@@ -12,7 +12,7 @@
     "@waku/core": "0.0.16",
     "@waku/create": "0.0.12",
     "@waku/interfaces": "0.0.11",
-    "@waku/noise": "0.0.3",
+    "@waku/noise": "0.0.4",
     "@waku/utils": "0.0.4",
     "protobufjs": "^7.1.2",
     "qrcode": "^1.5.1"

--- a/examples/noise-rtc/index.js
+++ b/examples/noise-rtc/index.js
@@ -26,13 +26,12 @@ async function main() {
 
     ui.waku.connected();
 
-    const responder = getResponder(node);
     const myStaticKey = noise.generateX25519KeyPair();
     const urlPairingInfo = getPairingInfoFromURL();
 
     const pairingObj = new noise.WakuPairing(
       node.lightPush,
-      responder,
+      node.filter,
       myStaticKey,
       urlPairingInfo || new noise.ResponderParameters()
     );
@@ -210,59 +209,6 @@ function getPairingInfoFromURL() {
     decodeURIComponent(qrCodeString),
     utils.hexToBytes(messageNameTag)
   );
-}
-
-function getResponder(node) {
-  const msgQueue = new Array();
-  const subscriptions = new Map();
-  const intervals = new Map();
-
-  const responder = {
-    async subscribe(decoder) {
-      const subscription = await node.filter.subscribe(
-        [decoder],
-        (wakuMessage) => {
-          msgQueue.push(wakuMessage);
-        }
-      );
-      subscriptions.set(decoder.contentTopic, subscription);
-    },
-    async nextMessage(contentTopic) {
-      if (msgQueue.length != 0) {
-        const oldestMsg = msgQueue.shift();
-        if (oldestMsg.contentTopic === contentTopic) {
-          return oldestMsg;
-        }
-      }
-
-      return new Promise((resolve) => {
-        const interval = setInterval(() => {
-          if (msgQueue.length != 0) {
-            clearInterval(interval);
-            const oldestMsg = msgQueue.shift();
-            if (oldestMsg.contentTopic === contentTopic) {
-              resolve(oldestMsg);
-            }
-          }
-        }, 100);
-        intervals.set(contentTopic, interval);
-      });
-    },
-    async stop(contentTopic) {
-      if (intervals.has(contentTopic)) {
-        clearInterval(intervals.get(contentTopic));
-        intervals.delete(contentTopic);
-      }
-      if (subscriptions.has(contentTopic)) {
-        await subscriptions.get(contentTopic)();
-        subscriptions.delete(contentTopic);
-      } else {
-        console.log("Subscriptipon doesnt exist");
-      }
-    },
-  };
-
-  return responder;
 }
 
 async function scheduleHandshakeAuthConfirmation(pairingObj, ui) {

--- a/examples/noise-rtc/package.json
+++ b/examples/noise-rtc/package.json
@@ -12,7 +12,7 @@
     "@waku/core": "0.0.16",
     "@waku/create": "0.0.12",
     "@waku/interfaces": "0.0.11",
-    "@waku/noise": "0.0.3",
+    "@waku/noise": "0.0.4",
     "@waku/utils": "0.0.4",
     "protobufjs": "^7.1.2",
     "qrcode": "^1.5.1"


### PR DESCRIPTION
This PR passes `node.filer` directly to noise. 
Partially resolves: https://github.com/waku-org/js-noise/issues/14