### PR TITLE
chore: bump basic examples to new version

### DIFF
--- a/examples/light-chat/index.js
+++ b/examples/light-chat/index.js
@@ -1,10 +1,10 @@
-import * as utils from "https://unpkg.com/@waku/utils@0.0.4/bundle/bytes.js";
-import * as wakuCreate from "https://unpkg.com/@waku/create@0.0.12/bundle/index.js";
+import * as utils from "https://unpkg.com/@waku/utils@0.0.5/bundle/bytes.js";
+import * as wakuCreate from "https://unpkg.com/@waku/create@0.0.13/bundle/index.js";
 import {
   waitForRemotePeer,
   createDecoder,
   createEncoder,
-} from "https://unpkg.com/@waku/core@0.0.16/bundle/index.js";
+} from "https://unpkg.com/@waku/core@0.0.17/bundle/index.js";
 
 const CONTENT_TOPIC = "/toy-chat/2/huilong/proto";
 

--- a/examples/light-js/index.html
+++ b/examples/light-js/index.html
@@ -42,13 +42,13 @@
 
     <script src="https://unpkg.com/@multiformats/multiaddr@12.1.1/dist/index.min.js"></script>
     <script type="module">
-      import * as utils from "https://unpkg.com/@waku/utils@0.0.4/bundle/bytes.js";
-      import { createLightNode } from "https://unpkg.com/@waku/create@0.0.12/bundle/index.js";
+      import * as utils from "https://unpkg.com/@waku/utils@0.0.5/bundle/bytes.js";
+      import { createLightNode } from "https://unpkg.com/@waku/create@0.0.13/bundle/index.js";
       import {
         waitForRemotePeer,
         createEncoder,
         createDecoder,
-      } from "https://unpkg.com/@waku/core@0.0.16/bundle/index.js";
+      } from "https://unpkg.com/@waku/core@0.0.17/bundle/index.js";
 
       const peerIdDiv = document.getElementById("peer-id");
       const remotePeerIdDiv = document.getElementById("remote-peer-id");

--- a/examples/relay-js/index.html
+++ b/examples/relay-js/index.html
@@ -36,13 +36,13 @@
       import {
         bytesToUtf8,
         utf8ToBytes,
-      } from "https://unpkg.com/@waku/utils@0.0.4/bundle/bytes.js";
-      import { createRelayNode } from "https://unpkg.com/@waku/create@0.0.12/bundle/index.js";
+      } from "https://unpkg.com/@waku/utils@0.0.5/bundle/bytes.js";
+      import { createRelayNode } from "https://unpkg.com/@waku/create@0.0.13/bundle/index.js";
       import {
         waitForRemotePeer,
         createDecoder,
         createEncoder,
-      } from "https://unpkg.com/@waku/core@0.0.16/bundle/index.js";
+      } from "https://unpkg.com/@waku/core@0.0.17/bundle/index.js";
 
       const statusDiv = document.getElementById("status");
       const messagesDiv = document.getElementById("messages");

--- a/examples/store-js/index.html
+++ b/examples/store-js/index.html
@@ -17,13 +17,13 @@
       import {
         defaultLibp2p,
         defaultPeerDiscovery,
-      } from "https://unpkg.com/@waku/create@0.0.12/bundle/index.js";
+      } from "https://unpkg.com/@waku/create@0.0.13/bundle/index.js";
       import {
         wakuStore,
         WakuNode,
         waitForRemotePeer,
         createDecoder,
-      } from "https://unpkg.com/@waku/core@0.0.16/bundle/index.js";
+      } from "https://unpkg.com/@waku/core@0.0.17/bundle/index.js";
 
       /**
        * This example demonstrates how to use the js-waku minified bundle


### PR DESCRIPTION
Updating basic JS examples to use latest version of:
- `@waku/create`;
- `@waku/core`;
- `@waku/utils`;

Release: https://github.com/waku-org/js-waku/pull/1296