### PR TITLE
feat: use @waku/sdk

### DIFF
--- a/examples/light-js/index.html
+++ b/examples/light-js/index.html
@@ -42,13 +42,13 @@
 
     <script src="https://unpkg.com/@multiformats/multiaddr@12.1.1/dist/index.min.js"></script>
     <script type="module">
-      import * as utils from "https://unpkg.com/@waku/utils@0.0.5/bundle/bytes.js";
-      import { createLightNode } from "https://unpkg.com/@waku/create@0.0.13/bundle/index.js";
       import {
+        createLightNode,
         waitForRemotePeer,
         createEncoder,
         createDecoder,
-      } from "https://unpkg.com/@waku/core@0.0.17/bundle/index.js";
+        utils,
+      } from "https://unpkg.com/@waku/sdk@0.0.16/bundle/index.js";
 
       const peerIdDiv = document.getElementById("peer-id");
       const remotePeerIdDiv = document.getElementById("remote-peer-id");

--- a/examples/light-js/index.html
+++ b/examples/light-js/index.html
@@ -47,7 +47,8 @@
         waitForRemotePeer,
         createEncoder,
         createDecoder,
-        utils,
+        utf8ToBytes,
+        bytesToUtf8,
       } from "https://unpkg.com/@waku/sdk@0.0.16/bundle/index.js";
 
       const peerIdDiv = document.getElementById("peer-id");
@@ -101,7 +102,7 @@
       };
 
       const callback = (wakuMessage) => {
-        const text = utils.bytesToUtf8(wakuMessage.payload);
+        const text = bytesToUtf8(wakuMessage.payload);
         const timestamp = wakuMessage.timestamp.toString();
         messages.push(text + " - " + timestamp);
         updateMessages(messages, messagesDiv);
@@ -124,7 +125,7 @@
         const text = textInput.value;
 
         await node.lightPush.send(encoder, {
-          payload: utils.utf8ToBytes(text),
+          payload: utf8ToBytes(text),
         });
         console.log("Message sent!");
         textInput.value = null;

--- a/examples/noise-js/index.js
+++ b/examples/noise-js/index.js
@@ -1,6 +1,5 @@
-import { createLightNode } from "@waku/create";
+import { createLightNode, waitForRemotePeer } from "@waku/sdk";
 import * as utils from "@waku/utils/bytes";
-import { waitForRemotePeer } from "@waku/core";
 import * as noise from "@waku/noise";
 import protobuf from "protobufjs";
 import QRCode from "qrcode";

--- a/examples/noise-js/package-lock.json
+++ b/examples/noise-js/package-lock.json
@@ -8,10 +8,9 @@
       "name": "@waku/noise-example",
       "version": "0.1.0",
       "dependencies": {
-        "@waku/core": "0.0.19",
-        "@waku/create": "0.0.15",
         "@waku/noise": "0.0.3-31510da",
-        "@waku/utils": "0.0.6",
+        "@waku/sdk": "0.0.16",
+        "@waku/utils": "0.0.8",
         "protobufjs": "^7.1.2",
         "qrcode": "^1.5.1"
       },
@@ -1754,144 +1753,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@waku/core": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.19.tgz",
-      "integrity": "sha512-rmgoX7Qx5UI73BMF58UUBaQv5JkHY00es+4Ig+OGQvPrY64jKno5ZLFUVhKzMF3n6WlRNf5kfdCr5MjQXrDygA==",
-      "dependencies": {
-        "@noble/hashes": "^1.3.0",
-        "@waku/interfaces": "0.0.14",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "it-all": "^3.0.1",
-        "it-length-prefixed": "^9.0.1",
-        "it-pipe": "^2.0.5",
-        "p-event": "^5.0.1",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@multiformats/multiaddr": "^12.0.0",
-        "libp2p": "^0.42.2"
-      },
-      "peerDependenciesMeta": {
-        "@multiformats/multiaddr": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@waku/core/node_modules/@waku/proto": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.5.tgz",
-      "integrity": "sha512-td0WKhUm+pcnpkbhuu5XV79ZcuM+f7b5swNIHHcqCaW5FaJeCtEhXsG8kNrt97kcDAHdr41lxFgQTRDlmAns4A==",
-      "dependencies": {
-        "protons-runtime": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/core/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/create": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@waku/create/-/create-0.0.15.tgz",
-      "integrity": "sha512-4O977FrFeToxagVAHMJtM1dPWZez8dpUaQB9ZqXsBD7LgC8Jh1IgPjgdDUv0141X/+b6QxiNDJZQAnTmTt8dNQ==",
-      "dependencies": {
-        "@chainsafe/libp2p-noise": "^11.0.0",
-        "@libp2p/mplex": "^7.1.1",
-        "@libp2p/websockets": "^5.0.3",
-        "@waku/core": "0.0.19",
-        "@waku/dns-discovery": "0.0.13",
-        "@waku/relay": "0.0.2",
-        "libp2p": "^0.42.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/dns-discovery": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.13.tgz",
-      "integrity": "sha512-HuyYs9iHfu8DIhJKxu1CDEVnwkQOAQtVQK+da52J9YIU1q2H4qM5UgVgEkIC7+L1jJgR7OZFvqrm3EhSuQ4AwA==",
-      "dependencies": {
-        "@libp2p/interface-peer-discovery": "^1.0.5",
-        "@libp2p/interfaces": "^3.3.1",
-        "@waku/enr": "0.0.13",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "dns-query": "^0.11.2",
-        "hi-base32": "^0.5.1",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/dns-discovery/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/enr": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.13.tgz",
-      "integrity": "sha512-nyHKYAkpYixtS//Wef/tHTvDkF/ZWydKx9+TfK9wH3nP9/FLBqFKuqDSNoxvaA7BliFicLvNRaGqmRdEQee0/g==",
-      "dependencies": {
-        "@ethersproject/rlp": "^5.7.0",
-        "@libp2p/crypto": "^1.0.15",
-        "@libp2p/peer-id": "^2.0.3",
-        "@multiformats/multiaddr": "^12.0.0",
-        "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "js-sha3": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/enr/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/interfaces": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.14.tgz",
-      "integrity": "sha512-YatgPAUCwtVmKkg+DJY7Q0oxfCiPn45OaK5RE+oJVoOEgLHcy1Ty4e6uIw+y3X9j7hcyWnZUAci836xPNo+/Lw==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@waku/noise": {
       "version": "0.0.3-31510da",
       "resolved": "https://registry.npmjs.org/@waku/noise/-/noise-0.0.3-31510da.tgz",
@@ -1979,26 +1840,99 @@
         "node": ">=16"
       }
     },
-    "node_modules/@waku/relay": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.2.tgz",
-      "integrity": "sha512-z2/wuqjUxv9WyYXDwPN3Rp0QUD/qiVlHaPJMQw0i3XsY1hfbR4QAvONDswnc91ikPhGKP3LzXA2kAqADPpRnqQ==",
+    "node_modules/@waku/sdk": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.16.tgz",
+      "integrity": "sha512-G9R+2rwOf8DE+lzLfcM5d5IICeRmktyfH4g77aWkgsBA5GvBJoMY5vnIS1j1tqJ+J4UfGp+CggHmHW+x9li1mA==",
       "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^6.1.0",
-        "@noble/hashes": "^1.3.0",
-        "@waku/core": "0.0.19",
-        "@waku/interfaces": "0.0.14",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.7",
-        "chai": "^4.3.7",
-        "debug": "^4.3.4",
-        "fast-check": "^3.8.1"
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/websockets": "^5.0.3",
+        "@waku/core": "0.0.20",
+        "@waku/dns-discovery": "0.0.14",
+        "@waku/relay": "0.0.3",
+        "@waku/utils": "0.0.8",
+        "libp2p": "^0.42.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@waku/relay/node_modules/@waku/proto": {
+    "node_modules/@waku/sdk/node_modules/@waku/core": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.20.tgz",
+      "integrity": "sha512-1p8TmOvbGhUQZHKE+w1FQtmp+EDTNQEsSgrsMoSjzGVdI+XuQQ/l2aefwOuBQHIHh99+VZBQ9ut+ArstFHks/A==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.0",
+        "@waku/interfaces": "0.0.15",
+        "@waku/proto": "0.0.5",
+        "@waku/utils": "0.0.8",
+        "debug": "^4.3.4",
+        "it-all": "^3.0.2",
+        "it-length-prefixed": "^9.0.1",
+        "it-pipe": "^3.0.1",
+        "p-event": "^5.0.1",
+        "uint8arraylist": "^2.4.3",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@multiformats/multiaddr": "^12.0.0",
+        "libp2p": "^0.42.2"
+      },
+      "peerDependenciesMeta": {
+        "@multiformats/multiaddr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/dns-discovery": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.14.tgz",
+      "integrity": "sha512-S8kzLUvmqIuqLGcPAT6JAYFDrxB/TeMEihU4tsWWg7UBnxyQVH2lqkjzGxnqClrQ9XFukvlH1fhvn0AIkKg25A==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^1.0.5",
+        "@libp2p/interfaces": "^3.3.1",
+        "@waku/enr": "0.0.14",
+        "@waku/utils": "0.0.8",
+        "debug": "^4.3.4",
+        "dns-query": "^0.11.2",
+        "hi-base32": "^0.5.1",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/enr": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.14.tgz",
+      "integrity": "sha512-oujSa7lVZoVEL2A/xA1UQqkktkeSL7I1ivt6hsMfK/3BbsQPt4d4LchY5QG7Vahrebv2BZ+/tvckhQ2mkF3azg==",
+      "dependencies": {
+        "@ethersproject/rlp": "^5.7.0",
+        "@libp2p/crypto": "^1.0.17",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@noble/secp256k1": "^1.7.1",
+        "@waku/utils": "0.0.8",
+        "debug": "^4.3.4",
+        "js-sha3": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/interfaces": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.15.tgz",
+      "integrity": "sha512-l8MDtMtA51nWeeU36lZV07JWMLHmnn7Dm93ihS2lgqWACbhzwOEDZ3alox4T8Um7A3RmnK/WZ5U2Cprs3ukt8w==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/proto": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.5.tgz",
       "integrity": "sha512-td0WKhUm+pcnpkbhuu5XV79ZcuM+f7b5swNIHHcqCaW5FaJeCtEhXsG8kNrt97kcDAHdr41lxFgQTRDlmAns4A==",
@@ -2009,22 +1943,64 @@
         "node": ">=16"
       }
     },
-    "node_modules/@waku/relay/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
+    "node_modules/@waku/sdk/node_modules/@waku/relay": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.3.tgz",
+      "integrity": "sha512-KDcfuOnTu/8HjNTwPXeVyd+qEIPZ7AXH0p4EwbfiucHbYWy7ahpljYz1fExwG7nKFsZ9uKtB7QGBBDy1ghKMCA==",
       "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^6.1.0",
+        "@noble/hashes": "^1.3.0",
+        "@waku/core": "0.0.20",
+        "@waku/interfaces": "0.0.15",
+        "@waku/proto": "0.0.5",
+        "@waku/utils": "0.0.8",
+        "chai": "^4.3.7",
         "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
+        "fast-check": "^3.8.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
+    "node_modules/@waku/sdk/node_modules/it-merge": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.1.tgz",
+      "integrity": "sha512-I6hjU1ABO+k3xY1H6JtCSDXvUME88pxIXSgKeT4WI5rPYbQzpr98ldacVuG95WbjaJxKl6Qot6lUdxduLBQPHA==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@waku/utils": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.6.tgz",
-      "integrity": "sha512-hyHeP3PLMoxWzg/ghQpagNZAm5G0nncuJSE1n/ml+4oeY5+oimF4Qh6PGXxakjJYKY5+JWN7Y3OHj+CO2cbKnA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.8.tgz",
+      "integrity": "sha512-pMs06f+P+jBq8v4Hyek7VTkCB0Suxc+baXqNfqTdM7xqzmwnCjfi1q9ummCln17Q3+6lVsbwHzUfikGTyoMeow==",
       "dependencies": {
         "debug": "^4.3.4",
         "uint8arrays": "^4.0.3"

--- a/examples/noise-js/package.json
+++ b/examples/noise-js/package.json
@@ -9,10 +9,9 @@
     "start": "webpack-dev-server"
   },
   "dependencies": {
-    "@waku/core": "0.0.19",
-    "@waku/create": "0.0.15",
+    "@waku/sdk": "0.0.16",
     "@waku/noise": "0.0.3-31510da",
-    "@waku/utils": "0.0.6",
+    "@waku/utils": "0.0.8",
     "protobufjs": "^7.1.2",
     "qrcode": "^1.5.1"
   },

--- a/examples/noise-rtc/index.js
+++ b/examples/noise-rtc/index.js
@@ -1,6 +1,5 @@
-import { createLightNode } from "@waku/create";
+import { createLightNode, waitForRemotePeer } from "@waku/sdk";
 import * as utils from "@waku/utils/bytes";
-import { waitForRemotePeer } from "@waku/core";
 import * as noise from "@waku/noise";
 import protobuf from "protobufjs";
 import QRCode from "qrcode";

--- a/examples/noise-rtc/package-lock.json
+++ b/examples/noise-rtc/package-lock.json
@@ -8,10 +8,9 @@
       "name": "@waku/noise-rtc",
       "version": "0.1.0",
       "dependencies": {
-        "@waku/core": "0.0.19",
-        "@waku/create": "0.0.15",
         "@waku/noise": "0.0.3-31510da",
-        "@waku/utils": "0.0.6",
+        "@waku/sdk": "0.0.16",
+        "@waku/utils": "0.0.8",
         "protobufjs": "^7.1.2",
         "qrcode": "^1.5.1"
       },
@@ -184,6 +183,57 @@
       "bin": {
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.4.tgz",
+      "integrity": "sha512-X7kA6a3/QPFxNFwgUJ8vubDu5qBDcDT0nhD+jL7g60IFKZu//HFH7oqsNCZa12yx0oR1fEYOR62iHDt2GHyWBQ==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@stablelib/chacha20poly1305": "^1.0.1",
+        "@stablelib/hkdf": "^1.0.1",
+        "@stablelib/sha256": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "it-length-prefixed": "^8.0.2",
+        "it-pair": "^2.0.2",
+        "it-pb-stream": "^3.2.0",
+        "it-pipe": "^2.0.3",
+        "it-stream-types": "^1.0.4",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@chainsafe/libp2p-noise/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@chainsafe/netmask": {
@@ -395,6 +445,41 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/interface-connection-encrypter": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
+      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-encrypter/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-connection-encrypter/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@libp2p/interface-connection-manager": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.4.tgz",
@@ -558,18 +643,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/interface-libp2p/node_modules/@libp2p/interface-metrics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/interface-libp2p/node_modules/@libp2p/interface-peer-id": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
@@ -583,6 +656,64 @@
       }
     },
     "node_modules/@libp2p/interface-libp2p/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.8.tgz",
+      "integrity": "sha512-1b9HjYyJH0m35kvPHipuoz2EtYCxyq34NUhuV8VK1VNtrouMpA3uCKp5FI7yHCA6V6+ux1R3UriKgNFOSGbIXQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/@libp2p/interface-connection": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.1.tgz",
+      "integrity": "sha512-ytknMbuuNW72LYMmTP7wFGP5ZTaUSGBCmV9f+uQ55XPcFHtKXLtKWVU/HE8IqPmwtyU8AO7veGoJ/qStMHNRVA==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-metrics/node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
@@ -799,6 +930,110 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/interface-stream-muxer": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.6.tgz",
+      "integrity": "sha512-wbLrH/bdF8qe0CpPd3BFMSmUs085vc3/8zx5uhXJySD672enAc8Jw9gmAYd1pIqELdqJqBDg9EI0y1XMRxvVkw==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-stream-types": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-stream-muxer/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.3.tgz",
+      "integrity": "sha512-ez+0X+w2Wyw3nJY6mP0DHFgrRnln/miAH4TJLcRfUSJHjGXH5ZfpuK1TnRxXpEUiqOezSbwke06/znI27KpRiQ==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface-transport/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@libp2p/interfaces": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
@@ -859,6 +1094,77 @@
       }
     },
     "node_modules/@libp2p/logger/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.7.tgz",
+      "integrity": "sha512-8eJ6HUL3bM8ck0rb/NJ04+phBUVBMocxH/kuc2Nypn8RX9ezihV7srGGhG5N7muaMwJrRbYkFhIV4GH+8WTZUg==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^4.0.2",
+        "any-signal": "^4.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^1.0.0",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^1.0.4",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/any-signal": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+      "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/mplex/node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
@@ -1315,18 +1621,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/tracked-map/node_modules/@libp2p/interface-metrics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@libp2p/utils": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.4.tgz",
@@ -1386,6 +1680,76 @@
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
       "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.10.tgz",
+      "integrity": "sha512-q8aKm0rhDxZjc4TzDpB0quog4pViFnz+Ok+UbGEk3xXxHwT3QCxaDVPKMemMqN/1N3OahVvcodpcvFSuWmus+A==",
+      "dependencies": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "abortable-iterator": "^4.0.2",
+        "it-ws": "^5.0.6",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/interface-connection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+      "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+      "dependencies": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@libp2p/interface-peer-id": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+      "dependencies": {
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/@multiformats/mafmt": {
+      "version": "12.1.5",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.5.tgz",
+      "integrity": "sha512-hz8CreKgs99pNIfea5/BHTPY90nrVLDHgGNrrHPCe51pkO+OM95PiF43q7ivIlytU++asOxcp+FhZymIwYy6LA==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "node_modules/@libp2p/websockets/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -1926,396 +2290,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@waku/core": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.19.tgz",
-      "integrity": "sha512-rmgoX7Qx5UI73BMF58UUBaQv5JkHY00es+4Ig+OGQvPrY64jKno5ZLFUVhKzMF3n6WlRNf5kfdCr5MjQXrDygA==",
-      "dependencies": {
-        "@noble/hashes": "^1.3.0",
-        "@waku/interfaces": "0.0.14",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "it-all": "^3.0.1",
-        "it-length-prefixed": "^9.0.1",
-        "it-pipe": "^2.0.5",
-        "p-event": "^5.0.1",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@multiformats/multiaddr": "^12.0.0",
-        "libp2p": "^0.42.2"
-      },
-      "peerDependenciesMeta": {
-        "@multiformats/multiaddr": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@waku/core/node_modules/@waku/proto": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.5.tgz",
-      "integrity": "sha512-td0WKhUm+pcnpkbhuu5XV79ZcuM+f7b5swNIHHcqCaW5FaJeCtEhXsG8kNrt97kcDAHdr41lxFgQTRDlmAns4A==",
-      "dependencies": {
-        "protons-runtime": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/core/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/core/node_modules/it-length-prefixed": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
-      "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^2.0.1",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/core/node_modules/it-stream-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
-      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/core/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@waku/create": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@waku/create/-/create-0.0.15.tgz",
-      "integrity": "sha512-4O977FrFeToxagVAHMJtM1dPWZez8dpUaQB9ZqXsBD7LgC8Jh1IgPjgdDUv0141X/+b6QxiNDJZQAnTmTt8dNQ==",
-      "dependencies": {
-        "@chainsafe/libp2p-noise": "^11.0.0",
-        "@libp2p/mplex": "^7.1.1",
-        "@libp2p/websockets": "^5.0.3",
-        "@waku/core": "0.0.19",
-        "@waku/dns-discovery": "0.0.13",
-        "@waku/relay": "0.0.2",
-        "libp2p": "^0.42.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@chainsafe/libp2p-noise": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.4.tgz",
-      "integrity": "sha512-X7kA6a3/QPFxNFwgUJ8vubDu5qBDcDT0nhD+jL7g60IFKZu//HFH7oqsNCZa12yx0oR1fEYOR62iHDt2GHyWBQ==",
-      "dependencies": {
-        "@libp2p/crypto": "^1.0.11",
-        "@libp2p/interface-connection-encrypter": "^3.0.5",
-        "@libp2p/interface-keys": "^1.0.6",
-        "@libp2p/interface-metrics": "^4.0.4",
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/logger": "^2.0.5",
-        "@libp2p/peer-id": "^2.0.0",
-        "@stablelib/chacha20poly1305": "^1.0.1",
-        "@stablelib/hkdf": "^1.0.1",
-        "@stablelib/sha256": "^1.0.1",
-        "@stablelib/x25519": "^1.0.3",
-        "it-length-prefixed": "^8.0.2",
-        "it-pair": "^2.0.2",
-        "it-pb-stream": "^3.2.0",
-        "it-pipe": "^2.0.3",
-        "it-stream-types": "^1.0.4",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.3.2",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/interface-connection": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.1.1.tgz",
-      "integrity": "sha512-+hxfYLv4jf+MruQEJiJeIyo/wI33/53wRL0XJTkxwQQPAkLHfZWCUY4kY9sXALd3+ASjXAENvJj9VvzZTlkRDQ==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/interface-connection-encrypter": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
-      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/interface-metrics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
-      "dependencies": {
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/interface-stream-muxer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
-      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "it-stream-types": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/interface-transport": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.2.tgz",
-      "integrity": "sha512-P3VpMJrYRlXGPAvn0E/X0d9GBszuopR8hhoZiOaZzOFsi9kTkL0rnTtggsXNByAnGDB9fwklqdutEi4POEQlXw==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "it-stream-types": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/mplex": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.3.tgz",
-      "integrity": "sha512-CBjN6otOYyJzogS0rgMnE7NwIC0c6OP6qLc/LybOcI16PJHn1gP25QWrWfNOl+K5M92ybwykMnB2cPi3blLH6Q==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.1",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interfaces": "^3.2.0",
-        "@libp2p/logger": "^2.0.0",
-        "abortable-iterator": "^4.0.2",
-        "any-signal": "^3.0.0",
-        "benchmark": "^2.1.4",
-        "it-batched-bytes": "^1.0.0",
-        "it-pushable": "^3.1.0",
-        "it-stream-types": "^1.0.4",
-        "rate-limiter-flexible": "^2.3.9",
-        "uint8arraylist": "^2.1.1",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@libp2p/websockets": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.8.tgz",
-      "integrity": "sha512-zeEiK7yozC4ebyqFP8y7RnRYKsClyrWn7QxKh2/n5xiUYwnavSocpeayOB57AOSs4WeBsdkunrJ2WbCyXEDLcQ==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.2",
-        "@libp2p/interface-transport": "^2.0.0",
-        "@libp2p/interfaces": "^3.0.3",
-        "@libp2p/logger": "^2.0.0",
-        "@libp2p/utils": "^3.0.2",
-        "@multiformats/mafmt": "^12.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "@multiformats/multiaddr-to-uri": "^9.0.2",
-        "abortable-iterator": "^4.0.2",
-        "it-ws": "^5.0.6",
-        "p-defer": "^4.0.0",
-        "p-timeout": "^6.0.0",
-        "wherearewe": "^2.0.1",
-        "ws": "^8.12.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/@multiformats/mafmt": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.0.tgz",
-      "integrity": "sha512-P3+cKi0EqqYGoF8IMK7dd8PFlanbvzzhem+tkcjrjGAPV5sVam2VfFAFNyzLTOP8dS/5Rf5pQ6LC0k6cO8WF5w==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/it-pb-stream": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-3.2.1.tgz",
-      "integrity": "sha512-vKE04Zv5MUcwxPNE9bIEfYK3rd/Klj5ORGD1D8Bn5f0mbCLGfouSrqZP1Jntg2osqQg4BN5dKKS2BbfwyGUI3Q==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-length-prefixed": "^9.0.0",
-        "it-pushable": "^3.1.2",
-        "it-stream-types": "^1.0.4",
-        "protons-runtime": "^5.0.0",
-        "uint8-varint": "^1.0.6",
-        "uint8arraylist": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/it-pb-stream/node_modules/it-length-prefixed": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.0.tgz",
-      "integrity": "sha512-LCne3R3wxxLv94GTA8ywIeopdyA+2oKXiWWo7g58sQHiD7d1A6WMuWCrwP+xv4i7CmSuR3aeHo66SJUgArLOyA==",
-      "dependencies": {
-        "err-code": "^3.0.1",
-        "it-stream-types": "^1.0.5",
-        "uint8-varint": "^1.0.1",
-        "uint8arraylist": "^2.0.0",
-        "uint8arrays": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/create/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@waku/dns-discovery": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.13.tgz",
-      "integrity": "sha512-HuyYs9iHfu8DIhJKxu1CDEVnwkQOAQtVQK+da52J9YIU1q2H4qM5UgVgEkIC7+L1jJgR7OZFvqrm3EhSuQ4AwA==",
-      "dependencies": {
-        "@libp2p/interface-peer-discovery": "^1.0.5",
-        "@libp2p/interfaces": "^3.3.1",
-        "@waku/enr": "0.0.13",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "dns-query": "^0.11.2",
-        "hi-base32": "^0.5.1",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/dns-discovery/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/enr": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.13.tgz",
-      "integrity": "sha512-nyHKYAkpYixtS//Wef/tHTvDkF/ZWydKx9+TfK9wH3nP9/FLBqFKuqDSNoxvaA7BliFicLvNRaGqmRdEQee0/g==",
-      "dependencies": {
-        "@ethersproject/rlp": "^5.7.0",
-        "@libp2p/crypto": "^1.0.15",
-        "@libp2p/peer-id": "^2.0.3",
-        "@multiformats/multiaddr": "^12.0.0",
-        "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "js-sha3": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/enr/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@waku/interfaces": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.14.tgz",
-      "integrity": "sha512-YatgPAUCwtVmKkg+DJY7Q0oxfCiPn45OaK5RE+oJVoOEgLHcy1Ty4e6uIw+y3X9j7hcyWnZUAci836xPNo+/Lw==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@waku/noise": {
       "version": "0.0.3-31510da",
       "resolved": "https://registry.npmjs.org/@waku/noise/-/noise-0.0.3-31510da.tgz",
@@ -2436,26 +2410,99 @@
         "node": ">=16"
       }
     },
-    "node_modules/@waku/relay": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.2.tgz",
-      "integrity": "sha512-z2/wuqjUxv9WyYXDwPN3Rp0QUD/qiVlHaPJMQw0i3XsY1hfbR4QAvONDswnc91ikPhGKP3LzXA2kAqADPpRnqQ==",
+    "node_modules/@waku/sdk": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.16.tgz",
+      "integrity": "sha512-G9R+2rwOf8DE+lzLfcM5d5IICeRmktyfH4g77aWkgsBA5GvBJoMY5vnIS1j1tqJ+J4UfGp+CggHmHW+x9li1mA==",
       "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^6.1.0",
-        "@noble/hashes": "^1.3.0",
-        "@waku/core": "0.0.19",
-        "@waku/interfaces": "0.0.14",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.7",
-        "chai": "^4.3.7",
-        "debug": "^4.3.4",
-        "fast-check": "^3.8.1"
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/websockets": "^5.0.3",
+        "@waku/core": "0.0.20",
+        "@waku/dns-discovery": "0.0.14",
+        "@waku/relay": "0.0.3",
+        "@waku/utils": "0.0.8",
+        "libp2p": "^0.42.2"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@waku/relay/node_modules/@waku/proto": {
+    "node_modules/@waku/sdk/node_modules/@waku/core": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.20.tgz",
+      "integrity": "sha512-1p8TmOvbGhUQZHKE+w1FQtmp+EDTNQEsSgrsMoSjzGVdI+XuQQ/l2aefwOuBQHIHh99+VZBQ9ut+ArstFHks/A==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.0",
+        "@waku/interfaces": "0.0.15",
+        "@waku/proto": "0.0.5",
+        "@waku/utils": "0.0.8",
+        "debug": "^4.3.4",
+        "it-all": "^3.0.2",
+        "it-length-prefixed": "^9.0.1",
+        "it-pipe": "^3.0.1",
+        "p-event": "^5.0.1",
+        "uint8arraylist": "^2.4.3",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@multiformats/multiaddr": "^12.0.0",
+        "libp2p": "^0.42.2"
+      },
+      "peerDependenciesMeta": {
+        "@multiformats/multiaddr": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/dns-discovery": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.14.tgz",
+      "integrity": "sha512-S8kzLUvmqIuqLGcPAT6JAYFDrxB/TeMEihU4tsWWg7UBnxyQVH2lqkjzGxnqClrQ9XFukvlH1fhvn0AIkKg25A==",
+      "dependencies": {
+        "@libp2p/interface-peer-discovery": "^1.0.5",
+        "@libp2p/interfaces": "^3.3.1",
+        "@waku/enr": "0.0.14",
+        "@waku/utils": "0.0.8",
+        "debug": "^4.3.4",
+        "dns-query": "^0.11.2",
+        "hi-base32": "^0.5.1",
+        "uint8arrays": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/enr": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.14.tgz",
+      "integrity": "sha512-oujSa7lVZoVEL2A/xA1UQqkktkeSL7I1ivt6hsMfK/3BbsQPt4d4LchY5QG7Vahrebv2BZ+/tvckhQ2mkF3azg==",
+      "dependencies": {
+        "@ethersproject/rlp": "^5.7.0",
+        "@libp2p/crypto": "^1.0.17",
+        "@libp2p/peer-id": "^2.0.3",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@noble/secp256k1": "^1.7.1",
+        "@waku/utils": "0.0.8",
+        "debug": "^4.3.4",
+        "js-sha3": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/interfaces": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.15.tgz",
+      "integrity": "sha512-l8MDtMtA51nWeeU36lZV07JWMLHmnn7Dm93ihS2lgqWACbhzwOEDZ3alox4T8Um7A3RmnK/WZ5U2Cprs3ukt8w==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/@waku/proto": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.5.tgz",
       "integrity": "sha512-td0WKhUm+pcnpkbhuu5XV79ZcuM+f7b5swNIHHcqCaW5FaJeCtEhXsG8kNrt97kcDAHdr41lxFgQTRDlmAns4A==",
@@ -2466,22 +2513,88 @@
         "node": ">=16"
       }
     },
-    "node_modules/@waku/relay/node_modules/@waku/utils": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-      "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
+    "node_modules/@waku/sdk/node_modules/@waku/relay": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.3.tgz",
+      "integrity": "sha512-KDcfuOnTu/8HjNTwPXeVyd+qEIPZ7AXH0p4EwbfiucHbYWy7ahpljYz1fExwG7nKFsZ9uKtB7QGBBDy1ghKMCA==",
       "dependencies": {
+        "@chainsafe/libp2p-gossipsub": "^6.1.0",
+        "@noble/hashes": "^1.3.0",
+        "@waku/core": "0.0.20",
+        "@waku/interfaces": "0.0.15",
+        "@waku/proto": "0.0.5",
+        "@waku/utils": "0.0.8",
+        "chai": "^4.3.7",
         "debug": "^4.3.4",
-        "uint8arrays": "^4.0.3"
+        "fast-check": "^3.8.1"
       },
       "engines": {
         "node": ">=16"
       }
     },
+    "node_modules/@waku/sdk/node_modules/it-length-prefixed": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+      "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/it-merge": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.1.tgz",
+      "integrity": "sha512-I6hjU1ABO+k3xY1H6JtCSDXvUME88pxIXSgKeT4WI5rPYbQzpr98ldacVuG95WbjaJxKl6Qot6lUdxduLBQPHA==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/it-pipe": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+      "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+      "dependencies": {
+        "it-merge": "^3.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@waku/sdk/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@waku/utils": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.6.tgz",
-      "integrity": "sha512-hyHeP3PLMoxWzg/ghQpagNZAm5G0nncuJSE1n/ml+4oeY5+oimF4Qh6PGXxakjJYKY5+JWN7Y3OHj+CO2cbKnA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.8.tgz",
+      "integrity": "sha512-pMs06f+P+jBq8v4Hyek7VTkCB0Suxc+baXqNfqTdM7xqzmwnCjfi1q9ummCln17Q3+6lVsbwHzUfikGTyoMeow==",
       "dependencies": {
         "debug": "^4.3.4",
         "uint8arrays": "^4.0.3"
@@ -4733,6 +4846,49 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/it-pb-stream": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-3.2.1.tgz",
+      "integrity": "sha512-vKE04Zv5MUcwxPNE9bIEfYK3rd/Klj5ORGD1D8Bn5f0mbCLGfouSrqZP1Jntg2osqQg4BN5dKKS2BbfwyGUI3Q==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^1.0.4",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.6",
+        "uint8arraylist": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pb-stream/node_modules/it-length-prefixed": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+      "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+      "dependencies": {
+        "err-code": "^3.0.1",
+        "it-stream-types": "^2.0.1",
+        "uint8-varint": "^1.0.1",
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-pb-stream/node_modules/it-length-prefixed/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/it-pipe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
@@ -4995,20 +5151,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/libp2p/node_modules/@libp2p/interface-connection-encrypter": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
-      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
-      "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "it-stream-types": "^1.0.4",
-        "uint8arraylist": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/libp2p/node_modules/@libp2p/interface-connection/node_modules/@multiformats/multiaddr": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
@@ -5057,72 +5199,12 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/libp2p/node_modules/@libp2p/interface-metrics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-      "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/libp2p/node_modules/@libp2p/interface-peer-id": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
       "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
       "dependencies": {
         "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/interface-stream-muxer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
-      "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "it-stream-types": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/interface-transport": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.2.tgz",
-      "integrity": "sha512-P3VpMJrYRlXGPAvn0E/X0d9GBszuopR8hhoZiOaZzOFsi9kTkL0rnTtggsXNByAnGDB9fwklqdutEi4POEQlXw==",
-      "dependencies": {
-        "@libp2p/interface-connection": "^3.0.0",
-        "@libp2p/interface-stream-muxer": "^3.0.0",
-        "@libp2p/interfaces": "^3.0.0",
-        "@multiformats/multiaddr": "^12.0.0",
-        "it-stream-types": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/@libp2p/interface-transport/node_modules/@multiformats/multiaddr": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
-      "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "@chainsafe/netmask": "^2.0.0",
-        "dns-over-http-resolver": "^2.1.0",
-        "err-code": "^3.0.1",
-        "multiformats": "^11.0.0",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -7662,6 +7744,47 @@
         }
       }
     },
+    "@chainsafe/libp2p-noise": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.4.tgz",
+      "integrity": "sha512-X7kA6a3/QPFxNFwgUJ8vubDu5qBDcDT0nhD+jL7g60IFKZu//HFH7oqsNCZa12yx0oR1fEYOR62iHDt2GHyWBQ==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-connection-encrypter": "^3.0.5",
+        "@libp2p/interface-keys": "^1.0.6",
+        "@libp2p/interface-metrics": "^4.0.4",
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.0",
+        "@stablelib/chacha20poly1305": "^1.0.1",
+        "@stablelib/hkdf": "^1.0.1",
+        "@stablelib/sha256": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3",
+        "it-length-prefixed": "^8.0.2",
+        "it-pair": "^2.0.2",
+        "it-pb-stream": "^3.2.0",
+        "it-pipe": "^2.0.3",
+        "it-stream-types": "^1.0.4",
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.3.2",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
     "@chainsafe/netmask": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
@@ -7836,6 +7959,31 @@
         }
       }
     },
+    "@libp2p/interface-connection-encrypter": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
+      "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
+      "requires": {
+        "@libp2p/interface-peer-id": "^2.0.0",
+        "it-stream-types": "^1.0.4",
+        "uint8arraylist": "^2.1.2"
+      },
+      "dependencies": {
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
     "@libp2p/interface-connection-manager": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.3.4.tgz",
@@ -7938,14 +8086,6 @@
             "multiformats": "^11.0.0"
           }
         },
-        "@libp2p/interface-metrics": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-          "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0"
-          }
-        },
         "@libp2p/interface-peer-id": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
@@ -7953,6 +8093,46 @@
           "requires": {
             "multiformats": "^11.0.0"
           }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/interface-metrics": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.8.tgz",
+      "integrity": "sha512-1b9HjYyJH0m35kvPHipuoz2EtYCxyq34NUhuV8VK1VNtrouMpA3uCKp5FI7yHCA6V6+ux1R3UriKgNFOSGbIXQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^5.0.0"
+      },
+      "dependencies": {
+        "@libp2p/interface-connection": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-5.1.1.tgz",
+          "integrity": "sha512-ytknMbuuNW72LYMmTP7wFGP5ZTaUSGBCmV9f+uQ55XPcFHtKXLtKWVU/HE8IqPmwtyU8AO7veGoJ/qStMHNRVA==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^2.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@multiformats/multiaddr": "^12.0.0",
+            "it-stream-types": "^2.0.1",
+            "uint8arraylist": "^2.4.3"
+          }
+        },
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "it-stream-types": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+          "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
         },
         "multiformats": {
           "version": "11.0.2",
@@ -8113,6 +8293,82 @@
         "@libp2p/interface-peer-id": "^1.0.0"
       }
     },
+    "@libp2p/interface-stream-muxer": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.6.tgz",
+      "integrity": "sha512-wbLrH/bdF8qe0CpPd3BFMSmUs085vc3/8zx5uhXJySD672enAc8Jw9gmAYd1pIqELdqJqBDg9EI0y1XMRxvVkw==",
+      "requires": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "it-stream-types": "^1.0.4"
+      },
+      "dependencies": {
+        "@libp2p/interface-connection": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+          "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^2.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@multiformats/multiaddr": "^12.0.0",
+            "it-stream-types": "^1.0.4",
+            "uint8arraylist": "^2.1.2"
+          }
+        },
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/interface-transport": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.3.tgz",
+      "integrity": "sha512-ez+0X+w2Wyw3nJY6mP0DHFgrRnln/miAH4TJLcRfUSJHjGXH5ZfpuK1TnRxXpEUiqOezSbwke06/znI27KpRiQ==",
+      "requires": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "it-stream-types": "^1.0.4"
+      },
+      "dependencies": {
+        "@libp2p/interface-connection": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+          "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^2.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@multiformats/multiaddr": "^12.0.0",
+            "it-stream-types": "^1.0.4",
+            "uint8arraylist": "^2.1.2"
+          }
+        },
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
     "@libp2p/interfaces": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
@@ -8151,6 +8407,59 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.0.tgz",
           "integrity": "sha512-mjUwX3XSoreoxCS3sXS3pSRsGnUjl9T06KBqt/T7AgE9Sgp4diH64ZyURJKnj2T5WmCvTbC0Dm+mwQV5hfLSBQ=="
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
+        }
+      }
+    },
+    "@libp2p/mplex": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.7.tgz",
+      "integrity": "sha512-8eJ6HUL3bM8ck0rb/NJ04+phBUVBMocxH/kuc2Nypn8RX9ezihV7srGGhG5N7muaMwJrRbYkFhIV4GH+8WTZUg==",
+      "requires": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-stream-muxer": "^3.0.0",
+        "@libp2p/interfaces": "^3.2.0",
+        "@libp2p/logger": "^2.0.0",
+        "abortable-iterator": "^4.0.2",
+        "any-signal": "^4.0.1",
+        "benchmark": "^2.1.4",
+        "it-batched-bytes": "^1.0.0",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^1.0.4",
+        "rate-limiter-flexible": "^2.3.9",
+        "uint8arraylist": "^2.1.1",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0"
+      },
+      "dependencies": {
+        "@libp2p/interface-connection": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+          "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^2.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@multiformats/multiaddr": "^12.0.0",
+            "it-stream-types": "^1.0.4",
+            "uint8arraylist": "^2.1.2"
+          }
+        },
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "any-signal": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-4.1.1.tgz",
+          "integrity": "sha512-iADenERppdC+A2YKbOXXB2WUeABLaM6qnpZ70kZbPZ1cZMMJ7eF+3CaYm+/PhBizgkzlvssC7QuHS30oOiQYWA=="
         },
         "multiformats": {
           "version": "11.0.2",
@@ -8493,16 +8802,6 @@
       "integrity": "sha512-mtsZWf2ntttuCrmEIro2p1ceCAaKde2TzT/99DZlkGdJN/Mo1jZgXq7ltZjWc8G3DAlgs+0ygjMzNKcZzAveuQ==",
       "requires": {
         "@libp2p/interface-metrics": "^4.0.0"
-      },
-      "dependencies": {
-        "@libp2p/interface-metrics": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-          "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0"
-          }
-        }
       }
     },
     "@libp2p/utils": {
@@ -8552,6 +8851,62 @@
           "version": "10.0.3",
           "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
           "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw=="
+        }
+      }
+    },
+    "@libp2p/websockets": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.10.tgz",
+      "integrity": "sha512-q8aKm0rhDxZjc4TzDpB0quog4pViFnz+Ok+UbGEk3xXxHwT3QCxaDVPKMemMqN/1N3OahVvcodpcvFSuWmus+A==",
+      "requires": {
+        "@libp2p/interface-connection": "^4.0.0",
+        "@libp2p/interface-transport": "^2.0.0",
+        "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/logger": "^2.0.0",
+        "@libp2p/utils": "^3.0.2",
+        "@multiformats/mafmt": "^12.0.0",
+        "@multiformats/multiaddr": "^12.0.0",
+        "@multiformats/multiaddr-to-uri": "^9.0.2",
+        "abortable-iterator": "^4.0.2",
+        "it-ws": "^5.0.6",
+        "p-defer": "^4.0.0",
+        "p-timeout": "^6.0.0",
+        "wherearewe": "^2.0.1",
+        "ws": "^8.12.1"
+      },
+      "dependencies": {
+        "@libp2p/interface-connection": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-4.0.0.tgz",
+          "integrity": "sha512-6xx/NmEc84HX7QmsjSC3hHredQYjHv4Dkf4G27adAPf+qN+vnPxmQ7gaTnk243a0++DOFTbZ2gKX/15G2B6SRg==",
+          "requires": {
+            "@libp2p/interface-peer-id": "^2.0.0",
+            "@libp2p/interfaces": "^3.0.0",
+            "@multiformats/multiaddr": "^12.0.0",
+            "it-stream-types": "^1.0.4",
+            "uint8arraylist": "^2.1.2"
+          }
+        },
+        "@libp2p/interface-peer-id": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+          "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
+          "requires": {
+            "multiformats": "^11.0.0"
+          }
+        },
+        "@multiformats/mafmt": {
+          "version": "12.1.5",
+          "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.5.tgz",
+          "integrity": "sha512-hz8CreKgs99pNIfea5/BHTPY90nrVLDHgGNrrHPCe51pkO+OM95PiF43q7ivIlytU++asOxcp+FhZymIwYy6LA==",
+          "requires": {
+            "@multiformats/multiaddr": "^12.0.0"
+          }
+        },
+        "multiformats": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
         }
       }
     },
@@ -9037,307 +9392,6 @@
         "@types/node": "*"
       }
     },
-    "@waku/core": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.19.tgz",
-      "integrity": "sha512-rmgoX7Qx5UI73BMF58UUBaQv5JkHY00es+4Ig+OGQvPrY64jKno5ZLFUVhKzMF3n6WlRNf5kfdCr5MjQXrDygA==",
-      "requires": {
-        "@noble/hashes": "^1.3.0",
-        "@waku/interfaces": "0.0.14",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "it-all": "^3.0.1",
-        "it-length-prefixed": "^9.0.1",
-        "it-pipe": "^2.0.5",
-        "p-event": "^5.0.1",
-        "uint8arraylist": "^2.4.3",
-        "uuid": "^9.0.0"
-      },
-      "dependencies": {
-        "@waku/proto": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.5.tgz",
-          "integrity": "sha512-td0WKhUm+pcnpkbhuu5XV79ZcuM+f7b5swNIHHcqCaW5FaJeCtEhXsG8kNrt97kcDAHdr41lxFgQTRDlmAns4A==",
-          "requires": {
-            "protons-runtime": "^5.0.0"
-          }
-        },
-        "@waku/utils": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-          "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-          "requires": {
-            "debug": "^4.3.4",
-            "uint8arrays": "^4.0.3"
-          }
-        },
-        "it-length-prefixed": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
-          "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "it-stream-types": "^2.0.1",
-            "uint8-varint": "^1.0.1",
-            "uint8arraylist": "^2.0.0",
-            "uint8arrays": "^4.0.2"
-          }
-        },
-        "it-stream-types": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
-          "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
-        },
-        "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
-        }
-      }
-    },
-    "@waku/create": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@waku/create/-/create-0.0.15.tgz",
-      "integrity": "sha512-4O977FrFeToxagVAHMJtM1dPWZez8dpUaQB9ZqXsBD7LgC8Jh1IgPjgdDUv0141X/+b6QxiNDJZQAnTmTt8dNQ==",
-      "requires": {
-        "@chainsafe/libp2p-noise": "^11.0.0",
-        "@libp2p/mplex": "^7.1.1",
-        "@libp2p/websockets": "^5.0.3",
-        "@waku/core": "0.0.19",
-        "@waku/dns-discovery": "0.0.13",
-        "@waku/relay": "0.0.2",
-        "libp2p": "^0.42.2"
-      },
-      "dependencies": {
-        "@chainsafe/libp2p-noise": {
-          "version": "11.0.4",
-          "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-11.0.4.tgz",
-          "integrity": "sha512-X7kA6a3/QPFxNFwgUJ8vubDu5qBDcDT0nhD+jL7g60IFKZu//HFH7oqsNCZa12yx0oR1fEYOR62iHDt2GHyWBQ==",
-          "requires": {
-            "@libp2p/crypto": "^1.0.11",
-            "@libp2p/interface-connection-encrypter": "^3.0.5",
-            "@libp2p/interface-keys": "^1.0.6",
-            "@libp2p/interface-metrics": "^4.0.4",
-            "@libp2p/interface-peer-id": "^2.0.0",
-            "@libp2p/logger": "^2.0.5",
-            "@libp2p/peer-id": "^2.0.0",
-            "@stablelib/chacha20poly1305": "^1.0.1",
-            "@stablelib/hkdf": "^1.0.1",
-            "@stablelib/sha256": "^1.0.1",
-            "@stablelib/x25519": "^1.0.3",
-            "it-length-prefixed": "^8.0.2",
-            "it-pair": "^2.0.2",
-            "it-pb-stream": "^3.2.0",
-            "it-pipe": "^2.0.3",
-            "it-stream-types": "^1.0.4",
-            "protons-runtime": "^5.0.0",
-            "uint8arraylist": "^2.3.2",
-            "uint8arrays": "^4.0.2"
-          }
-        },
-        "@libp2p/interface-connection": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-3.1.1.tgz",
-          "integrity": "sha512-+hxfYLv4jf+MruQEJiJeIyo/wI33/53wRL0XJTkxwQQPAkLHfZWCUY4kY9sXALd3+ASjXAENvJj9VvzZTlkRDQ==",
-          "requires": {
-            "@libp2p/interface-peer-id": "^2.0.0",
-            "@libp2p/interfaces": "^3.0.0",
-            "@multiformats/multiaddr": "^12.0.0",
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^2.1.2"
-          }
-        },
-        "@libp2p/interface-connection-encrypter": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
-          "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
-          "requires": {
-            "@libp2p/interface-peer-id": "^2.0.0",
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^2.1.2"
-          }
-        },
-        "@libp2p/interface-metrics": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-          "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0"
-          }
-        },
-        "@libp2p/interface-peer-id": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-          "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
-          "requires": {
-            "multiformats": "^11.0.0"
-          }
-        },
-        "@libp2p/interface-stream-muxer": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
-          "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0",
-            "@libp2p/interfaces": "^3.0.0",
-            "it-stream-types": "^1.0.4"
-          }
-        },
-        "@libp2p/interface-transport": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.2.tgz",
-          "integrity": "sha512-P3VpMJrYRlXGPAvn0E/X0d9GBszuopR8hhoZiOaZzOFsi9kTkL0rnTtggsXNByAnGDB9fwklqdutEi4POEQlXw==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0",
-            "@libp2p/interface-stream-muxer": "^3.0.0",
-            "@libp2p/interfaces": "^3.0.0",
-            "@multiformats/multiaddr": "^12.0.0",
-            "it-stream-types": "^1.0.4"
-          }
-        },
-        "@libp2p/mplex": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-7.1.3.tgz",
-          "integrity": "sha512-CBjN6otOYyJzogS0rgMnE7NwIC0c6OP6qLc/LybOcI16PJHn1gP25QWrWfNOl+K5M92ybwykMnB2cPi3blLH6Q==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.1",
-            "@libp2p/interface-stream-muxer": "^3.0.0",
-            "@libp2p/interfaces": "^3.2.0",
-            "@libp2p/logger": "^2.0.0",
-            "abortable-iterator": "^4.0.2",
-            "any-signal": "^3.0.0",
-            "benchmark": "^2.1.4",
-            "it-batched-bytes": "^1.0.0",
-            "it-pushable": "^3.1.0",
-            "it-stream-types": "^1.0.4",
-            "rate-limiter-flexible": "^2.3.9",
-            "uint8arraylist": "^2.1.1",
-            "uint8arrays": "^4.0.2",
-            "varint": "^6.0.0"
-          }
-        },
-        "@libp2p/websockets": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-5.0.8.tgz",
-          "integrity": "sha512-zeEiK7yozC4ebyqFP8y7RnRYKsClyrWn7QxKh2/n5xiUYwnavSocpeayOB57AOSs4WeBsdkunrJ2WbCyXEDLcQ==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.2",
-            "@libp2p/interface-transport": "^2.0.0",
-            "@libp2p/interfaces": "^3.0.3",
-            "@libp2p/logger": "^2.0.0",
-            "@libp2p/utils": "^3.0.2",
-            "@multiformats/mafmt": "^12.0.0",
-            "@multiformats/multiaddr": "^12.0.0",
-            "@multiformats/multiaddr-to-uri": "^9.0.2",
-            "abortable-iterator": "^4.0.2",
-            "it-ws": "^5.0.6",
-            "p-defer": "^4.0.0",
-            "p-timeout": "^6.0.0",
-            "wherearewe": "^2.0.1",
-            "ws": "^8.12.1"
-          }
-        },
-        "@multiformats/mafmt": {
-          "version": "12.1.0",
-          "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.0.tgz",
-          "integrity": "sha512-P3+cKi0EqqYGoF8IMK7dd8PFlanbvzzhem+tkcjrjGAPV5sVam2VfFAFNyzLTOP8dS/5Rf5pQ6LC0k6cO8WF5w==",
-          "requires": {
-            "@multiformats/multiaddr": "^12.0.0"
-          }
-        },
-        "it-pb-stream": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-3.2.1.tgz",
-          "integrity": "sha512-vKE04Zv5MUcwxPNE9bIEfYK3rd/Klj5ORGD1D8Bn5f0mbCLGfouSrqZP1Jntg2osqQg4BN5dKKS2BbfwyGUI3Q==",
-          "requires": {
-            "err-code": "^3.0.1",
-            "it-length-prefixed": "^9.0.0",
-            "it-pushable": "^3.1.2",
-            "it-stream-types": "^1.0.4",
-            "protons-runtime": "^5.0.0",
-            "uint8-varint": "^1.0.6",
-            "uint8arraylist": "^2.0.0"
-          },
-          "dependencies": {
-            "it-length-prefixed": {
-              "version": "9.0.0",
-              "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.0.tgz",
-              "integrity": "sha512-LCne3R3wxxLv94GTA8ywIeopdyA+2oKXiWWo7g58sQHiD7d1A6WMuWCrwP+xv4i7CmSuR3aeHo66SJUgArLOyA==",
-              "requires": {
-                "err-code": "^3.0.1",
-                "it-stream-types": "^1.0.5",
-                "uint8-varint": "^1.0.1",
-                "uint8arraylist": "^2.0.0",
-                "uint8arrays": "^4.0.2"
-              }
-            }
-          }
-        },
-        "multiformats": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-          "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-        }
-      }
-    },
-    "@waku/dns-discovery": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.13.tgz",
-      "integrity": "sha512-HuyYs9iHfu8DIhJKxu1CDEVnwkQOAQtVQK+da52J9YIU1q2H4qM5UgVgEkIC7+L1jJgR7OZFvqrm3EhSuQ4AwA==",
-      "requires": {
-        "@libp2p/interface-peer-discovery": "^1.0.5",
-        "@libp2p/interfaces": "^3.3.1",
-        "@waku/enr": "0.0.13",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "dns-query": "^0.11.2",
-        "hi-base32": "^0.5.1",
-        "uint8arrays": "^4.0.3"
-      },
-      "dependencies": {
-        "@waku/utils": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-          "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-          "requires": {
-            "debug": "^4.3.4",
-            "uint8arrays": "^4.0.3"
-          }
-        }
-      }
-    },
-    "@waku/enr": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.13.tgz",
-      "integrity": "sha512-nyHKYAkpYixtS//Wef/tHTvDkF/ZWydKx9+TfK9wH3nP9/FLBqFKuqDSNoxvaA7BliFicLvNRaGqmRdEQee0/g==",
-      "requires": {
-        "@ethersproject/rlp": "^5.7.0",
-        "@libp2p/crypto": "^1.0.15",
-        "@libp2p/peer-id": "^2.0.3",
-        "@multiformats/multiaddr": "^12.0.0",
-        "@noble/secp256k1": "^1.7.1",
-        "@waku/utils": "0.0.7",
-        "debug": "^4.3.4",
-        "js-sha3": "^0.8.0"
-      },
-      "dependencies": {
-        "@waku/utils": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-          "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
-          "requires": {
-            "debug": "^4.3.4",
-            "uint8arrays": "^4.0.3"
-          }
-        }
-      }
-    },
-    "@waku/interfaces": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.14.tgz",
-      "integrity": "sha512-YatgPAUCwtVmKkg+DJY7Q0oxfCiPn45OaK5RE+oJVoOEgLHcy1Ty4e6uIw+y3X9j7hcyWnZUAci836xPNo+/Lw=="
-    },
     "@waku/noise": {
       "version": "0.0.3-31510da",
       "resolved": "https://registry.npmjs.org/@waku/noise/-/noise-0.0.3-31510da.tgz",
@@ -9425,22 +9479,74 @@
         "protons-runtime": "^5.0.0"
       }
     },
-    "@waku/relay": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.2.tgz",
-      "integrity": "sha512-z2/wuqjUxv9WyYXDwPN3Rp0QUD/qiVlHaPJMQw0i3XsY1hfbR4QAvONDswnc91ikPhGKP3LzXA2kAqADPpRnqQ==",
+    "@waku/sdk": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/@waku/sdk/-/sdk-0.0.16.tgz",
+      "integrity": "sha512-G9R+2rwOf8DE+lzLfcM5d5IICeRmktyfH4g77aWkgsBA5GvBJoMY5vnIS1j1tqJ+J4UfGp+CggHmHW+x9li1mA==",
       "requires": {
-        "@chainsafe/libp2p-gossipsub": "^6.1.0",
-        "@noble/hashes": "^1.3.0",
-        "@waku/core": "0.0.19",
-        "@waku/interfaces": "0.0.14",
-        "@waku/proto": "0.0.5",
-        "@waku/utils": "0.0.7",
-        "chai": "^4.3.7",
-        "debug": "^4.3.4",
-        "fast-check": "^3.8.1"
+        "@chainsafe/libp2p-noise": "^11.0.0",
+        "@libp2p/mplex": "^7.1.1",
+        "@libp2p/websockets": "^5.0.3",
+        "@waku/core": "0.0.20",
+        "@waku/dns-discovery": "0.0.14",
+        "@waku/relay": "0.0.3",
+        "@waku/utils": "0.0.8",
+        "libp2p": "^0.42.2"
       },
       "dependencies": {
+        "@waku/core": {
+          "version": "0.0.20",
+          "resolved": "https://registry.npmjs.org/@waku/core/-/core-0.0.20.tgz",
+          "integrity": "sha512-1p8TmOvbGhUQZHKE+w1FQtmp+EDTNQEsSgrsMoSjzGVdI+XuQQ/l2aefwOuBQHIHh99+VZBQ9ut+ArstFHks/A==",
+          "requires": {
+            "@noble/hashes": "^1.3.0",
+            "@waku/interfaces": "0.0.15",
+            "@waku/proto": "0.0.5",
+            "@waku/utils": "0.0.8",
+            "debug": "^4.3.4",
+            "it-all": "^3.0.2",
+            "it-length-prefixed": "^9.0.1",
+            "it-pipe": "^3.0.1",
+            "p-event": "^5.0.1",
+            "uint8arraylist": "^2.4.3",
+            "uuid": "^9.0.0"
+          }
+        },
+        "@waku/dns-discovery": {
+          "version": "0.0.14",
+          "resolved": "https://registry.npmjs.org/@waku/dns-discovery/-/dns-discovery-0.0.14.tgz",
+          "integrity": "sha512-S8kzLUvmqIuqLGcPAT6JAYFDrxB/TeMEihU4tsWWg7UBnxyQVH2lqkjzGxnqClrQ9XFukvlH1fhvn0AIkKg25A==",
+          "requires": {
+            "@libp2p/interface-peer-discovery": "^1.0.5",
+            "@libp2p/interfaces": "^3.3.1",
+            "@waku/enr": "0.0.14",
+            "@waku/utils": "0.0.8",
+            "debug": "^4.3.4",
+            "dns-query": "^0.11.2",
+            "hi-base32": "^0.5.1",
+            "uint8arrays": "^4.0.3"
+          }
+        },
+        "@waku/enr": {
+          "version": "0.0.14",
+          "resolved": "https://registry.npmjs.org/@waku/enr/-/enr-0.0.14.tgz",
+          "integrity": "sha512-oujSa7lVZoVEL2A/xA1UQqkktkeSL7I1ivt6hsMfK/3BbsQPt4d4LchY5QG7Vahrebv2BZ+/tvckhQ2mkF3azg==",
+          "requires": {
+            "@ethersproject/rlp": "^5.7.0",
+            "@libp2p/crypto": "^1.0.17",
+            "@libp2p/peer-id": "^2.0.3",
+            "@multiformats/multiaddr": "^12.0.0",
+            "@noble/secp256k1": "^1.7.1",
+            "@waku/utils": "0.0.8",
+            "debug": "^4.3.4",
+            "js-sha3": "^0.8.0"
+          }
+        },
+        "@waku/interfaces": {
+          "version": "0.0.15",
+          "resolved": "https://registry.npmjs.org/@waku/interfaces/-/interfaces-0.0.15.tgz",
+          "integrity": "sha512-l8MDtMtA51nWeeU36lZV07JWMLHmnn7Dm93ihS2lgqWACbhzwOEDZ3alox4T8Um7A3RmnK/WZ5U2Cprs3ukt8w=="
+        },
         "@waku/proto": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/@waku/proto/-/proto-0.0.5.tgz",
@@ -9449,21 +9555,68 @@
             "protons-runtime": "^5.0.0"
           }
         },
-        "@waku/utils": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.7.tgz",
-          "integrity": "sha512-qo9B807Fp8Sg5QHK47WewIsQbnDvgCtBs/nlQWqwWLg5HfAfISRpnfQ6tLQYvzXD+0OAPwcsSqYIiQ7rIOm0kA==",
+        "@waku/relay": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/@waku/relay/-/relay-0.0.3.tgz",
+          "integrity": "sha512-KDcfuOnTu/8HjNTwPXeVyd+qEIPZ7AXH0p4EwbfiucHbYWy7ahpljYz1fExwG7nKFsZ9uKtB7QGBBDy1ghKMCA==",
           "requires": {
+            "@chainsafe/libp2p-gossipsub": "^6.1.0",
+            "@noble/hashes": "^1.3.0",
+            "@waku/core": "0.0.20",
+            "@waku/interfaces": "0.0.15",
+            "@waku/proto": "0.0.5",
+            "@waku/utils": "0.0.8",
+            "chai": "^4.3.7",
             "debug": "^4.3.4",
-            "uint8arrays": "^4.0.3"
+            "fast-check": "^3.8.1"
           }
+        },
+        "it-length-prefixed": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+          "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "it-stream-types": "^2.0.1",
+            "uint8-varint": "^1.0.1",
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "it-merge": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.1.tgz",
+          "integrity": "sha512-I6hjU1ABO+k3xY1H6JtCSDXvUME88pxIXSgKeT4WI5rPYbQzpr98ldacVuG95WbjaJxKl6Qot6lUdxduLBQPHA==",
+          "requires": {
+            "it-pushable": "^3.1.0"
+          }
+        },
+        "it-pipe": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-3.0.1.tgz",
+          "integrity": "sha512-sIoNrQl1qSRg2seYSBH/3QxWhJFn9PKYvOf/bHdtCBF0bnghey44VyASsWzn5dAx0DCDDABq1hZIuzKmtBZmKA==",
+          "requires": {
+            "it-merge": "^3.0.0",
+            "it-pushable": "^3.1.2",
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "it-stream-types": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+          "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
     "@waku/utils": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.6.tgz",
-      "integrity": "sha512-hyHeP3PLMoxWzg/ghQpagNZAm5G0nncuJSE1n/ml+4oeY5+oimF4Qh6PGXxakjJYKY5+JWN7Y3OHj+CO2cbKnA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@waku/utils/-/utils-0.0.8.tgz",
+      "integrity": "sha512-pMs06f+P+jBq8v4Hyek7VTkCB0Suxc+baXqNfqTdM7xqzmwnCjfi1q9ummCln17Q3+6lVsbwHzUfikGTyoMeow==",
       "requires": {
         "debug": "^4.3.4",
         "uint8arrays": "^4.0.3"
@@ -11180,6 +11333,41 @@
         "p-defer": "^4.0.0"
       }
     },
+    "it-pb-stream": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pb-stream/-/it-pb-stream-3.2.1.tgz",
+      "integrity": "sha512-vKE04Zv5MUcwxPNE9bIEfYK3rd/Klj5ORGD1D8Bn5f0mbCLGfouSrqZP1Jntg2osqQg4BN5dKKS2BbfwyGUI3Q==",
+      "requires": {
+        "err-code": "^3.0.1",
+        "it-length-prefixed": "^9.0.0",
+        "it-pushable": "^3.1.2",
+        "it-stream-types": "^1.0.4",
+        "protons-runtime": "^5.0.0",
+        "uint8-varint": "^1.0.6",
+        "uint8arraylist": "^2.0.0"
+      },
+      "dependencies": {
+        "it-length-prefixed": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-9.0.1.tgz",
+          "integrity": "sha512-ZBD8ZFLERj8d1q9CeBtk0eJ4EpeI3qwnkmWtemBSm3ZI2dM8PUweNVk5haZ2vw3EIq2uYQiabV9YwNm6EASM4A==",
+          "requires": {
+            "err-code": "^3.0.1",
+            "it-stream-types": "^2.0.1",
+            "uint8-varint": "^1.0.1",
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
+          },
+          "dependencies": {
+            "it-stream-types": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+              "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
+            }
+          }
+        }
+      }
+    },
     "it-pipe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
@@ -11408,16 +11596,6 @@
             }
           }
         },
-        "@libp2p/interface-connection-encrypter": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-3.0.6.tgz",
-          "integrity": "sha512-LwyYBN/aSa3IPCe7gBxffx/vaC0rFxAXlCbx4QGaWGtg6qK80Ouj89LEDWb3HkMbecNVWaV4TEqJIM5WnAAx1Q==",
-          "requires": {
-            "@libp2p/interface-peer-id": "^2.0.0",
-            "it-stream-types": "^1.0.4",
-            "uint8arraylist": "^2.1.2"
-          }
-        },
         "@libp2p/interface-content-routing": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/@libp2p/interface-content-routing/-/interface-content-routing-2.0.2.tgz",
@@ -11440,58 +11618,12 @@
             "multiformats": "^11.0.0"
           }
         },
-        "@libp2p/interface-metrics": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-metrics/-/interface-metrics-4.0.5.tgz",
-          "integrity": "sha512-srBeky1ugu1Bzw9VHGg8ta15oLh+P2PEIsg0cI9qzDbtCJaWGq/IIetpfuaJNVOuBD1CGEEbITNmsk4tDwIE0w==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0"
-          }
-        },
         "@libp2p/interface-peer-id": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
           "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
           "requires": {
             "multiformats": "^11.0.0"
-          }
-        },
-        "@libp2p/interface-stream-muxer": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-stream-muxer/-/interface-stream-muxer-3.0.5.tgz",
-          "integrity": "sha512-815aJ+qVswNcTEOuOUTcB+7OLzAfROyjjqoWpK0bD0P/xqTHqOQcqdaDuK02zPuAZqYq9uR3+SoBasrCg6k3zw==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0",
-            "@libp2p/interfaces": "^3.0.0",
-            "it-stream-types": "^1.0.4"
-          }
-        },
-        "@libp2p/interface-transport": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@libp2p/interface-transport/-/interface-transport-2.1.2.tgz",
-          "integrity": "sha512-P3VpMJrYRlXGPAvn0E/X0d9GBszuopR8hhoZiOaZzOFsi9kTkL0rnTtggsXNByAnGDB9fwklqdutEi4POEQlXw==",
-          "requires": {
-            "@libp2p/interface-connection": "^3.0.0",
-            "@libp2p/interface-stream-muxer": "^3.0.0",
-            "@libp2p/interfaces": "^3.0.0",
-            "@multiformats/multiaddr": "^12.0.0",
-            "it-stream-types": "^1.0.4"
-          },
-          "dependencies": {
-            "@multiformats/multiaddr": {
-              "version": "12.1.0",
-              "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.0.tgz",
-              "integrity": "sha512-sGuMrF7Ysfozx2VxyF7j2I4gy0s6nUIb05aPT4uJFpzhgHP4pNLTpQSU27sfxzMMti9LVq2kBRiFpIWnK7hTBg==",
-              "requires": {
-                "@chainsafe/is-ip": "^2.0.1",
-                "@chainsafe/netmask": "^2.0.0",
-                "dns-over-http-resolver": "^2.1.0",
-                "err-code": "^3.0.1",
-                "multiformats": "^11.0.0",
-                "uint8arrays": "^4.0.2",
-                "varint": "^6.0.0"
-              }
-            }
           }
         },
         "@multiformats/multiaddr": {

--- a/examples/noise-rtc/package.json
+++ b/examples/noise-rtc/package.json
@@ -9,10 +9,9 @@
     "start": "webpack-dev-server"
   },
   "dependencies": {
-    "@waku/core": "0.0.19",
-    "@waku/create": "0.0.15",
+    "@waku/sdk": "0.0.16",
     "@waku/noise": "0.0.3-31510da",
-    "@waku/utils": "0.0.6",
+    "@waku/utils": "0.0.8",
     "protobufjs": "^7.1.2",
     "qrcode": "^1.5.1"
   },

--- a/examples/relay-js/index.html
+++ b/examples/relay-js/index.html
@@ -34,15 +34,13 @@
        */
 
       import {
-        bytesToUtf8,
-        utf8ToBytes,
-      } from "https://unpkg.com/@waku/utils@0.0.5/bundle/bytes.js";
-      import { createRelayNode } from "https://unpkg.com/@waku/create@0.0.13/bundle/index.js";
-      import {
         waitForRemotePeer,
         createDecoder,
         createEncoder,
-      } from "https://unpkg.com/@waku/core@0.0.17/bundle/index.js";
+        bytesToUtf8,
+        utf8ToBytes,
+        createRelayNode,
+      } from "https://unpkg.com/@waku/sdk@0.0.16/bundle/index.js";
 
       const statusDiv = document.getElementById("status");
       const messagesDiv = document.getElementById("messages");

--- a/examples/rln-js/index.js
+++ b/examples/rln-js/index.js
@@ -1,10 +1,10 @@
-import * as utils from "https://unpkg.com/@waku/utils@0.0.4/bundle/bytes.js";
-import { createLightNode } from "https://unpkg.com/@waku/create@0.0.12/bundle/index.js";
+import * as utils from "https://unpkg.com/@waku/utils@0.0.8/bundle/bytes.js";
 import {
   createEncoder,
   createDecoder,
   waitForRemotePeer,
-} from "https://unpkg.com/@waku/core@0.0.16/bundle/index.js";
+  createLightNode,
+} from "https://unpkg.com/@waku/sdk@0.0.16/bundle/index.js";
 import { protobuf } from "https://taisukef.github.io/protobuf-es.js/dist/protobuf-es.js";
 import {
   create,
@@ -284,8 +284,8 @@ function initUI() {
   const membershipIdInput = document.getElementById("membership-id");
   const idSecretHashInput = document.getElementById("id-secret-hash");
   const commitmentKeyInput = document.getElementById("commitment-key");
-  const idTrapdoorInput = document.getElementById("id-trapdoor")
-  const idNullifierInput = document.getElementById("id-nullifier")
+  const idTrapdoorInput = document.getElementById("id-trapdoor");
+  const idNullifierInput = document.getElementById("id-nullifier");
   const importManually = document.getElementById("import-manually-button");
   const importFromWalletButton = document.getElementById(
     "import-from-wallet-button"
@@ -418,9 +418,13 @@ function initUI() {
         const idCommitment = utils.hexToBytes(commitmentKeyInput.value);
         const idSecretHash = utils.hexToBytes(idSecretHashInput.value);
 
-
         const membershipId = membershipIdInput.value;
-        const credentials = new IdentityCredential(idTrapdoor, idNullifier, idSecretHash, idCommitment);
+        const credentials = new IdentityCredential(
+          idTrapdoor,
+          idNullifier,
+          idSecretHash,
+          idCommitment
+        );
 
         fn(membershipId, credentials);
       });


### PR DESCRIPTION
Migrate main and simple JS examples to use `@waku/sdk`. 

Next steps:
- migrate more complex examples one by one;
- check if there are no regressions in the new release;

Resolves the last part of https://github.com/waku-org/js-waku/issues/1353

