### PR TITLE
chore: update paths in quick use instructions in README

### DIFF
--- a/examples/eth-pm/README.md
+++ b/examples/eth-pm/README.md
@@ -24,7 +24,7 @@ To run a development version locally, do:
 
 ```shell
 git clone https://github.com/waku-org/js-waku-examples
-cd eth-pm
+cd js-waku-examples/examples/eth-pm
 npm install
 npm run start
 ```

--- a/examples/relay-angular-chat/README.md
+++ b/examples/relay-angular-chat/README.md
@@ -16,7 +16,7 @@ To run a development version locally, do:
 
 ```shell
 git clone https://github.com/waku-org/js-waku-examples
-cd relay-angular-chat
+cd js-waku-examples/examples/relay-angular-chat
 npm install
 npm start
 ```

--- a/examples/relay-reactjs-chat/README.md
+++ b/examples/relay-reactjs-chat/README.md
@@ -16,7 +16,7 @@ To run a development version locally, do:
 
 ```shell
 git clone https://github.com/waku-org/js-waku-examples
-cd relay-reactjs-chat
+cd js-waku-examples/examples/relay-reactjs-chat
 npm install
 npm run start
 ```

--- a/examples/rln-js/README.md
+++ b/examples/rln-js/README.md
@@ -19,7 +19,7 @@ To test the example:
 
 ```shell
 git clone https://github.com/waku-org/js-waku-examples
-cd js-waku-examples/rln-js
+cd js-waku-examples/examples/rln-js
 npm install
 npm run start
 # open  http://127.0.0.1:8080 In your browser

--- a/examples/store-reactjs-chat/README.md
+++ b/examples/store-reactjs-chat/README.md
@@ -15,7 +15,7 @@ To run a development version locally, do:
 
 ```shell
 git clone https://github.com/waku-org/js-waku-examples
-cd store-reactjs-chat
+cd js-waku-examples/examples/store-reactjs-chat
 npm install
 npm run start
 ```

--- a/examples/web-chat/README.md
+++ b/examples/web-chat/README.md
@@ -17,7 +17,7 @@ To run a development version locally, do:
 
 ```shell
 git clone https://github.com/waku-org/js-waku-examples
-cd web-chat   
+cd js-waku-examples/examples/web-chat
 npm install
 npm run start
 ```


### PR DESCRIPTION
Updated paths for quick copy and use instructions in README for some of the examples. 
Commands listed don't work if someone tries to use just by copy pasting them, since the paths for cd are not relative to previous command.