### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @waku-org/js-waku-developers 


### PR DESCRIPTION
Adding missing `CODEOWNERS` file and setting it to `js-waku` team. 