### PR TITLE
fix: mitigate hanging of web-chat

### DIFF
--- a/examples/web-chat/src/App.tsx
+++ b/examples/web-chat/src/App.tsx
@@ -9,7 +9,7 @@ import { useMessages, usePersistentNick } from "./hooks";
 
 const startTime = new Date();
 // Only retrieve a week of history
-startTime.setTime(Date.now() - 1000 * 60 * 60 * 24 * 7);
+startTime.setTime(Date.now() - 1000 * 60 * 30);
 const endTime = new Date();
 
 export default function App() {


### PR DESCRIPTION
Strange thing happened and @vpavlin while sending `base64` messages through `rpc` to his `nwaku` node put such a message into Store that while web-chat example tries to fetch them hangs and tab crashed. 

As mitigation right now - setting limit to last 30 minutes.

Will look into it later. 